### PR TITLE
feat: in and out attributes management

### DIFF
--- a/src/HybRunner.cs
+++ b/src/HybRunner.cs
@@ -644,32 +644,6 @@ namespace Hybridizer.Runtime.CUDAImports
         }
 
         /// <summary>
-        /// Configures a launch (CUDA-only)
-        /// </summary>
-        /// <param name="gridDimX"></param>
-        /// <param name="gridDimY"></param>
-        /// <param name="gridDimZ"></param>
-        /// <param name="blockDimX"></param>
-        /// <param name="blockDimY"></param>
-        /// <param name="blockDimZ"></param>
-        /// <param name="shared"></param>
-        /// <returns></returns>
-        public HybRunner SetDistrib(int gridDimX, int gridDimY,  int gridDimZ, int blockDimX, int blockDimY, int blockDimZ, int shared)
-        {   
-            if (_flavor == HybridizerFlavor.AVX && (gridDimZ != 1 || gridDimY != 1 || blockDimX != 32 || blockDimY != 1 || blockDimZ != 1))
-                throw new ApplicationException("Invalid work distributions parameters");
-
-            _gridDimX = gridDimX;
-            _gridDimY = gridDimY;
-            _gridDimZ = gridDimZ;
-            _blockDimX = blockDimX;
-            _blockDimY = blockDimY;
-            _blockDimZ = blockDimZ;
-            _shared = shared;
-            return this;
-        }
-
-        /// <summary>
         /// Sets the shared memory size parameter for a launch (CUDA-only)
         /// </summary>
         /// <param name="shared"></param>

--- a/src/HybRunner.cs
+++ b/src/HybRunner.cs
@@ -33,7 +33,9 @@ namespace Hybridizer.Runtime.CUDAImports
         internal delegate HybridizerProperties HybridizerGetProperties();
 
         private delegate IntPtr MarshalManagedToNativeDel(object p);
+        private delegate IntPtr MarshalManagedToNativeSkipDel(object p, bool skipMemcpy);
         private delegate void CleanUpManagedDataDel(object p);
+        private delegate void CleanUpManagedDataSkipDel(object p, bool skipMemcpy);
         private delegate HandleDelegate GetHandleDelegateDel(Delegate p);
         private delegate bool GetCleanUpManagedDataDel();
 
@@ -99,20 +101,26 @@ namespace Hybridizer.Runtime.CUDAImports
 
         #region Marshaller methods
         static MethodInfo marshalManagedToNative;
+        static MethodInfo marshalManagedToNativeSkip;
         static MethodInfo getHandleDelegate;
         static MethodInfo cleanUpManagedData;
+        static MethodInfo cleanUpManagedDataSkip;
         static MethodInfo getCleanUpManagedData;
 
         private void initDelegates()
         {
             MarshalManagedToNativeDel marshallDel = _marshaller.MarshalManagedToNative;
+            MarshalManagedToNativeSkipDel marshalSkipDel = new MarshalManagedToNativeSkipDel(_marshaller.MarshalManagedToNative);
             CleanUpManagedDataDel cleanupDel = _marshaller.CleanUpManagedData;
+            CleanUpManagedDataSkipDel cleanupSkipDel = new CleanUpManagedDataSkipDel(_marshaller.CleanUpManagedData);
             GetHandleDelegateDel getHandleDelegateDel = _marshaller.GetHandleDelegate;
             GetCleanUpManagedDataDel GetCleanUpManagedDataDel = _marshaller.IsCleanUpNativeData;
 
             marshalManagedToNative = marshallDel.Method;
+            marshalManagedToNativeSkip = marshalSkipDel.Method;
             getHandleDelegate = getHandleDelegateDel.Method;
             cleanUpManagedData = cleanupDel.Method;
+            cleanUpManagedDataSkip = cleanupSkipDel.Method;
             getCleanUpManagedData = GetCleanUpManagedDataDel.Method;
         }
         #endregion
@@ -627,6 +635,7 @@ namespace Hybridizer.Runtime.CUDAImports
 
             _gridDimX = gridDimX;
             _gridDimY = gridDimY;
+            _gridDimZ = 1;
             _blockDimX = blockDimX;
             _blockDimY = blockDimY;
             _blockDimZ = blockDimZ;
@@ -1106,14 +1115,15 @@ namespace Hybridizer.Runtime.CUDAImports
         }
 
         private void EmitMethod(ILGenerator ilgen, FieldInfo runtimeField, bool supportsOmp, MethodInfo toWrap,
-            FieldInfo wrappedObject, List<Type> wrappedParams, MethodBuilder nativeMetodOMP, 
-            MethodBuilder nativeMetod, MethodBuilder nativeMethodStream, MethodBuilder nativeMethodStreamGridSync, MethodBuilder nativeMethodGridSync, 
+            FieldInfo wrappedObject, List<Type> wrappedParams, MethodBuilder nativeMetodOMP,
+            MethodBuilder nativeMetod, MethodBuilder nativeMethodStream, MethodBuilder nativeMethodStreamGridSync, MethodBuilder nativeMethodGridSync,
             bool managedFallback)
         {
             BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
             MethodInfo marshallerGetter = typeof(HybRunner).GetProperty("Marshaller", bindingFlags).GetGetMethod();
             Label endOfMethod = ilgen.DefineLabel();
             LocalBuilder result = ilgen.DeclareLocal(typeof(int));
+            ParameterInfo[] parameters = toWrap.GetParameters();
 
 
             if (_marshaller is CudaMarshaler && managedFallback)
@@ -1143,7 +1153,7 @@ namespace Hybridizer.Runtime.CUDAImports
 
                 ilgen.MarkLabel(cudaLabel);
             }
-            
+
             if (supportsOmp)
             {
                 LocalBuilder isOmpCall = ilgen.DeclareLocal(typeof(bool));
@@ -1162,7 +1172,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 ilgen.Emit(OpCodes.Ldfld, runtimeField);
                 ilgen.Emit(OpCodes.Call,
                     typeof(HybRunner).GetProperty("GridDimX", bindingFlags).GetGetMethod());
-                AddParametersToStack(toWrap, ilgen, runtimeField, marshallerGetter, wrappedObject, wrappedParams);
+                AddParametersToStack(toWrap, ilgen, runtimeField, marshallerGetter, wrappedObject, wrappedParams, parameters);
                 ilgen.Emit(OpCodes.Call, nativeMetodOMP);
                 ilgen.Emit(OpCodes.Stloc, result);
                 var endOfCall = ilgen.DefineLabel();
@@ -1172,15 +1182,15 @@ namespace Hybridizer.Runtime.CUDAImports
                 // The non OMP version of the call
                 _stopWatchLastKernel.Start();
 
-                CallNativeMethod(ilgen, runtimeField, bindingFlags, toWrap, 
-                                marshallerGetter, wrappedObject, wrappedParams, 
+                CallNativeMethod(ilgen, runtimeField, bindingFlags, toWrap,
+                                marshallerGetter, wrappedObject, wrappedParams, parameters,
                                 nativeMetod, nativeMethodStream, nativeMethodStreamGridSync, nativeMethodGridSync, result);
                 ilgen.MarkLabel(endOfCall);
             }
             else
             {
-                CallNativeMethod(ilgen, runtimeField, bindingFlags, toWrap, 
-                    marshallerGetter, wrappedObject, wrappedParams, 
+                CallNativeMethod(ilgen, runtimeField, bindingFlags, toWrap,
+                    marshallerGetter, wrappedObject, wrappedParams, parameters,
                     nativeMetod, nativeMethodStream, nativeMethodStreamGridSync, nativeMethodGridSync, result);
             }
 
@@ -1205,16 +1215,26 @@ namespace Hybridizer.Runtime.CUDAImports
                 }
                 argIdx++;
 
-                foreach (Type pi in wrappedParams)
+                for (int i = 0; i < wrappedParams.Count; i++)
                 {
+                    Type pi = wrappedParams[i];
                     if (pi.IsClass || pi.IsInterface)
                     {
-                        // TODO: support manual cleanup here
+                        bool isInOnly = parameters[i].IsIn && !parameters[i].IsOut;
+
                         ilgen.Emit(OpCodes.Ldarg_0);
                         ilgen.Emit(OpCodes.Ldfld, runtimeField);
                         ilgen.Emit(OpCodes.Call, marshallerGetter);
                         ilgen.Emit(OpCodes.Ldarg, argIdx);
-                        ilgen.Emit(OpCodes.Call, cleanUpManagedData);
+                        if (isInOnly)
+                        {
+                            ilgen.Emit(OpCodes.Ldc_I4_1); // skipMemcpy = true
+                            ilgen.Emit(OpCodes.Call, cleanUpManagedDataSkip);
+                        }
+                        else
+                        {
+                            ilgen.Emit(OpCodes.Call, cleanUpManagedData);
+                        }
                     }
                     argIdx++;
                 }
@@ -1260,7 +1280,7 @@ namespace Hybridizer.Runtime.CUDAImports
             }
         }
 
-        private void CallNativeMethod(ILGenerator ilgen, FieldInfo runtimeField, BindingFlags bindingFlags, MethodInfo toWrap, MethodInfo marshallerGetter, FieldInfo wrappedObject, List<Type> wrappedParams, MethodBuilder nativeMetod, MethodBuilder nativeMethodStream, MethodBuilder nativeMethodStreamGridSync, MethodBuilder nativeMethodGridSync, LocalBuilder result)
+        private void CallNativeMethod(ILGenerator ilgen, FieldInfo runtimeField, BindingFlags bindingFlags, MethodInfo toWrap, MethodInfo marshallerGetter, FieldInfo wrappedObject, List<Type> wrappedParams, ParameterInfo[] parameters, MethodBuilder nativeMetod, MethodBuilder nativeMethodStream, MethodBuilder nativeMethodStreamGridSync, MethodBuilder nativeMethodGridSync, LocalBuilder result)
         {
             ilgen.Emit(OpCodes.Ldarg_0);
             ilgen.Emit(OpCodes.Ldfld, runtimeField);
@@ -1278,7 +1298,7 @@ namespace Hybridizer.Runtime.CUDAImports
             ilgen.Emit(OpCodes.Brtrue, streamLabel);
 
             LoadCommonParameters(ilgen, runtimeField, bindingFlags);
-            AddParametersToStack(toWrap, ilgen, runtimeField, marshallerGetter, wrappedObject, wrappedParams);
+            AddParametersToStack(toWrap, ilgen, runtimeField, marshallerGetter, wrappedObject, wrappedParams, parameters);
 
             if (_marshaller is CudaMarshaler)
             {
@@ -1310,7 +1330,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 ilgen.Emit(OpCodes.Ldarg_0);
                 ilgen.Emit(OpCodes.Ldfld, runtimeField);
                 ilgen.Emit(OpCodes.Call, typeof(HybRunner).GetProperty("Stream").GetGetMethod());
-                AddParametersToStack(toWrap, ilgen, runtimeField, marshallerGetter, wrappedObject, wrappedParams);
+                AddParametersToStack(toWrap, ilgen, runtimeField, marshallerGetter, wrappedObject, wrappedParams, parameters);
 
                 ilgen.Emit(OpCodes.Ldarg_0);
                 ilgen.Emit(OpCodes.Ldfld, runtimeField);
@@ -1356,10 +1376,10 @@ namespace Hybridizer.Runtime.CUDAImports
         }
 
         private static void AddParametersToStack(MethodInfo toWrap, ILGenerator generator, FieldInfo runtimeField,
-            MethodInfo marshallerGetter, FieldInfo wrappedObject, List<Type> wrappedParams)
+            MethodInfo marshallerGetter, FieldInfo wrappedObject, List<Type> wrappedParams, ParameterInfo[] parameters)
         {
             int argIdx = 0;
-            // marshal this
+            // marshal this — always normal (no In/Out on self)
             if (!toWrap.IsStatic)
             {
                 generator.Emit(OpCodes.Ldarg_0);
@@ -1371,8 +1391,11 @@ namespace Hybridizer.Runtime.CUDAImports
             }
             argIdx++;
 
-            foreach (Type parameterType in wrappedParams)
+            for (int i = 0; i < wrappedParams.Count; i++)
             {
+                Type parameterType = wrappedParams[i];
+                bool isOutOnly = parameters[i].IsOut && !parameters[i].IsIn;
+
                 if (IsDelegateType(parameterType))
                 {
                     // Convert to HandleDelegate
@@ -1390,7 +1413,15 @@ namespace Hybridizer.Runtime.CUDAImports
                     generator.Emit(OpCodes.Ldfld, runtimeField);
                     generator.Emit(OpCodes.Call, marshallerGetter);
                     generator.Emit(OpCodes.Ldarg, argIdx++);
-                    generator.Emit(OpCodes.Call, marshalManagedToNative);
+                    if (isOutOnly)
+                    {
+                        generator.Emit(OpCodes.Ldc_I4_1); // skipMemcpy = true
+                        generator.Emit(OpCodes.Call, marshalManagedToNativeSkip);
+                    }
+                    else
+                    {
+                        generator.Emit(OpCodes.Call, marshalManagedToNative);
+                    }
                 }
                 else
                 {

--- a/src/HybRunner.cs
+++ b/src/HybRunner.cs
@@ -84,6 +84,7 @@ namespace Hybridizer.Runtime.CUDAImports
         private int _blockDimZ = 1;
         private int _gridDimX = 1;
         private int _gridDimY = 1;
+        private int _gridDimZ = 1;
         private int _shared;
         private IntPtr _dllPtr = IntPtr.Zero;
         private Stopwatch _stopWatchLastKernel = new Stopwatch();
@@ -228,6 +229,14 @@ namespace Hybridizer.Runtime.CUDAImports
         public int GridDimY
         {
             get { return _gridDimY; }
+        }
+
+        /// <summary>
+        /// grid dimension Z
+        /// </summary>
+        public int GridDimZ
+        {
+            get { return _gridDimZ; }
         }
 
         /// <summary>
@@ -626,6 +635,32 @@ namespace Hybridizer.Runtime.CUDAImports
         }
 
         /// <summary>
+        /// Configures a launch (CUDA-only)
+        /// </summary>
+        /// <param name="gridDimX"></param>
+        /// <param name="gridDimY"></param>
+        /// <param name="gridDimZ"></param>
+        /// <param name="blockDimX"></param>
+        /// <param name="blockDimY"></param>
+        /// <param name="blockDimZ"></param>
+        /// <param name="shared"></param>
+        /// <returns></returns>
+        public HybRunner SetDistrib(int gridDimX, int gridDimY,  int gridDimZ, int blockDimX, int blockDimY, int blockDimZ, int shared)
+        {   
+            if (_flavor == HybridizerFlavor.AVX && (gridDimZ != 1 || gridDimY != 1 || blockDimX != 32 || blockDimY != 1 || blockDimZ != 1))
+                throw new ApplicationException("Invalid work distributions parameters");
+
+            _gridDimX = gridDimX;
+            _gridDimY = gridDimY;
+            _gridDimZ = gridDimZ;
+            _blockDimX = blockDimX;
+            _blockDimY = blockDimY;
+            _blockDimZ = blockDimZ;
+            _shared = shared;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the shared memory size parameter for a launch (CUDA-only)
         /// </summary>
         /// <param name="shared"></param>
@@ -740,7 +775,8 @@ namespace Hybridizer.Runtime.CUDAImports
                     ilgen.Emit(OpCodes.Call, mi); // call corresponding setdistrib method
                                                   // SetDistrib returns HybRunner => trash it
                     ilgen.Emit(OpCodes.Pop);
-                    ilgen.Emit(OpCodes.Ldarg_0); ilgen.Emit(OpCodes.Ret); // return this
+                    ilgen.Emit(OpCodes.Ldarg_0); 
+                    ilgen.Emit(OpCodes.Ret); // return this
                 }
                 {
                     MethodBuilder mb = typeBuilder.DefineMethod("SetDistrib", MethodAttributes.Public, typeBuilder, new Type[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) });
@@ -757,7 +793,27 @@ namespace Hybridizer.Runtime.CUDAImports
                     ilgen.Emit(OpCodes.Call, mi); // call corresponding setdistrib method
                                                   // SetDistrib returns HybRunner => trash it
                     ilgen.Emit(OpCodes.Pop);
-                    ilgen.Emit(OpCodes.Ldarg_0); ilgen.Emit(OpCodes.Ret); // return this
+                    ilgen.Emit(OpCodes.Ldarg_0); 
+                    ilgen.Emit(OpCodes.Ret); // return this
+                }
+                {
+                    MethodBuilder mb = typeBuilder.DefineMethod("SetDistrib", MethodAttributes.Public, typeBuilder, new Type[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) });
+                    ILGenerator ilgen = mb.GetILGenerator();
+                    ilgen.Emit(OpCodes.Ldarg_0);
+                    ilgen.Emit(OpCodes.Ldfld, runtimeField); // load the hybrunner instance attached to the wrapper
+                    ilgen.Emit(OpCodes.Ldarg_1);
+                    ilgen.Emit(OpCodes.Ldarg_2);
+                    ilgen.Emit(OpCodes.Ldarg_3);
+                    ilgen.Emit(OpCodes.Ldarg, 4);
+                    ilgen.Emit(OpCodes.Ldarg, 5);
+                    ilgen.Emit(OpCodes.Ldarg, 6);
+                    ilgen.Emit(OpCodes.Ldarg, 7);
+                    MethodInfo mi = typeof(HybRunner).GetMethod("SetDistrib", new Type[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) });
+                    ilgen.Emit(OpCodes.Call, mi); // call corresponding setdistrib method
+                                                  // SetDistrib returns HybRunner => trash it
+                    ilgen.Emit(OpCodes.Pop);
+                    ilgen.Emit(OpCodes.Ldarg_0); 
+                    ilgen.Emit(OpCodes.Ret); // return this
                 }
                 {
                     MethodBuilder mb = typeBuilder.DefineMethod("SetDistrib", MethodAttributes.Public, typeBuilder, new Type[] { typeof(dim3), typeof(dim3) });
@@ -836,6 +892,7 @@ namespace Hybridizer.Runtime.CUDAImports
                     {
                         nativeParameters.Add(typeof(int)); // griddim_x
                         nativeParameters.Add(typeof(int)); // griddim_y
+                        nativeParameters.Add(typeof(int)); // griddim_z
                         nativeParameters.Add(typeof(int)); // blockDim_x
                         nativeParameters.Add(typeof(int)); // blockdim_y
                         nativeParameters.Add(typeof(int)); // blockdim_z
@@ -879,7 +936,7 @@ namespace Hybridizer.Runtime.CUDAImports
                     {
                         List<Type> streamParameters = new List<Type>(nativeParameters.Count + 1);
                         streamParameters.AddRange(nativeParameters);
-                        streamParameters.Insert(6, typeof(cudaStream_t));
+                        streamParameters.Insert(7, typeof(cudaStream_t));
                         nativeMethodStream = GetNativeMethod(typeBuilder, symbol + "_ExternCWrapperStream_" + _flavor, streamParameters.ToArray());
                         nativeMethodGridSync = GetNativeMethod(typeBuilder, symbol + "_ExternCWrapperGridSync_" + _flavor, nativeParameters.ToArray());
                         nativeMethodStreamGridSync = GetNativeMethod(typeBuilder, symbol + "_ExternCWrapperStreamGridSync_" + _flavor, streamParameters.ToArray());
@@ -1180,6 +1237,9 @@ namespace Hybridizer.Runtime.CUDAImports
                 ilgen.Emit(OpCodes.Ldarg_0);
                 ilgen.Emit(OpCodes.Ldfld, runtimeField);
                 ilgen.Emit(OpCodes.Call, typeof(HybRunner).GetProperty("GridDimY", bindingFlags).GetGetMethod());
+                ilgen.Emit(OpCodes.Ldarg_0);
+                ilgen.Emit(OpCodes.Ldfld, runtimeField);
+                ilgen.Emit(OpCodes.Call, typeof(HybRunner).GetProperty("GridDimZ", bindingFlags).GetGetMethod());
                 ilgen.Emit(OpCodes.Ldarg_0);
                 ilgen.Emit(OpCodes.Ldfld, runtimeField);
                 ilgen.Emit(OpCodes.Call, typeof(HybRunner).GetProperty("BlockDimX", bindingFlags).GetGetMethod());

--- a/src/HybRunner.cs
+++ b/src/HybRunner.cs
@@ -644,6 +644,32 @@ namespace Hybridizer.Runtime.CUDAImports
         }
 
         /// <summary>
+        /// Configures a launch (CUDA-only)
+        /// </summary>
+        /// <param name="gridDimX"></param>
+        /// <param name="gridDimY"></param>
+        /// <param name="gridDimZ"></param>
+        /// <param name="blockDimX"></param>
+        /// <param name="blockDimY"></param>
+        /// <param name="blockDimZ"></param>
+        /// <param name="shared"></param>
+        /// <returns></returns>
+        public HybRunner SetDistrib(int gridDimX, int gridDimY, int gridDimZ, int blockDimX, int blockDimY, int blockDimZ, int shared)
+        {
+            if (_flavor == HybridizerFlavor.AVX && (gridDimZ != 1 || gridDimY != 1 || blockDimX != 32 || blockDimY != 1 || blockDimZ != 1))
+                throw new ApplicationException("Invalid work distributions parameters");
+
+            _gridDimX = gridDimX;
+            _gridDimY = gridDimY;
+            _gridDimZ = gridDimZ;
+            _blockDimX = blockDimX;
+            _blockDimY = blockDimY;
+            _blockDimZ = blockDimZ;
+            _shared = shared;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the shared memory size parameter for a launch (CUDA-only)
         /// </summary>
         /// <param name="shared"></param>

--- a/src/KernelInteropTools.cs
+++ b/src/KernelInteropTools.cs
@@ -91,13 +91,13 @@ namespace Hybridizer.Runtime.CUDAImports
 
         const int RTLD_LAZY = 1;
         const int RTLD_NOW = 2;
-        [DllImport("libdl.so", CharSet=CharSet.Ansi)]
+        [DllImport("libdl.so.2", CharSet=CharSet.Ansi)]
         private static extern IntPtr dlopen(String fileName, int flags);
-        [DllImport("libdl.so")]
+        [DllImport("libdl.so.2")]
         private static extern IntPtr dlsym(IntPtr handle, String symbol);
-        [DllImport("libdl.so")]
+        [DllImport("libdl.so.2")]
         private static extern int dlclose(IntPtr handle);
-        [DllImport("libdl.so")]
+        [DllImport("libdl.so.2")]
         private static extern IntPtr dlerror();
     }
 

--- a/src/Marshalling/Internal/AbstractObjectVisiter.cs
+++ b/src/Marshalling/Internal/AbstractObjectVisiter.cs
@@ -23,7 +23,7 @@ namespace Hybridizer.Runtime.CUDAImports
         {
             protected NativeSerializerState serState;
 
-            internal abstract IntPtr VisitObject(object o, IntPtr da);
+            internal abstract IntPtr VisitObject(object o, IntPtr da, bool skipMemcpy = false);
             protected abstract FieldVisitor CreateFieldVisitor();
 
             protected AbstractObjectVisiter(NativeSerializerState state)
@@ -38,7 +38,7 @@ namespace Hybridizer.Runtime.CUDAImports
             /// </summary>
             /// <param name="param"></param>
             /// <returns></returns>
-            public abstract IntPtr InitialVisit(object param);
+            public abstract IntPtr InitialVisit(object param, bool skipMemcpy = false);
         }
     }
 }

--- a/src/Marshalling/Internal/Cuda/Aggregated/Deserializer/CUDAAggregatedDeserializer.cs
+++ b/src/Marshalling/Internal/Cuda/Aggregated/Deserializer/CUDAAggregatedDeserializer.cs
@@ -24,22 +24,22 @@ namespace Hybridizer.Runtime.CUDAImports
                 this.state = state;
             }
 
-            public override IntPtr InitialVisit(object param)
+            public override IntPtr InitialVisit(object param, bool skipMemcpy = false)
             {
                 state.InitializeStream();
-                IntPtr res = base.InitialVisit(param);
+                IntPtr res = base.InitialVisit(param, skipMemcpy);
                 state.StreamSynchronize();
                 return res;
 
             }
 
-            protected override void DeserializeRawData(byte[] data, IntPtr da, long size)
+            protected override void DeserializeRawData(byte[] data, IntPtr da, long size, bool skipMemcpy = false)
             {
                 var gcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
                 state.CudaMemCopy(Marshal.UnsafeAddrOfPinnedArrayElement(data, 0), da, size, cudaMemcpyKind.cudaMemcpyDeviceToHost, gcHandle, false, true);
             }
 
-            protected override void DeserializeArray(object param, IntPtr da, Type type)
+            protected override void DeserializeArray(object param, IntPtr da, Type type, bool skipMemcpy = false)
             {
                 uint elementCount = GetElementCount(param as Array);
                 uint size = SizeOfArrayElt(type.GetElementType()) * elementCount;

--- a/src/Marshalling/Internal/Cuda/Aggregated/Deserializer/CUDAAggregatedObjectDeserializer.cs
+++ b/src/Marshalling/Internal/Cuda/Aggregated/Deserializer/CUDAAggregatedObjectDeserializer.cs
@@ -24,7 +24,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 this.state = state;
             }
 
-            internal override void start(object param, Type type, IntPtr da)
+            internal override void start(object param, Type type, IntPtr da, bool skipMemcpy = false)
             {
                 uint size = (uint)FieldTools.SizeOf(type);
                 long expected = serState.nativePtrConverter.Convert(type).ToInt64();

--- a/src/Marshalling/Internal/Cuda/Aggregated/Serializer/CUDAAggregatedObjectSerializer.cs
+++ b/src/Marshalling/Internal/Cuda/Aggregated/Serializer/CUDAAggregatedObjectSerializer.cs
@@ -30,9 +30,9 @@ namespace Hybridizer.Runtime.CUDAImports
                 this.state = state;
             }
 
-            internal override void start(object param, Type type, IntPtr da)
+            internal override void start(object param, Type type, IntPtr da, bool skipMemcpy = false)
             {
-                base.start(param, type, da);
+                base.start(param, type, da, skipMemcpy);
                 long size = serState.nativePtrConverter.GetTypeInfo(param.GetType()).size;
                 if (size <= MAX_SIZE_FOR_AGGREGATION)
                 {
@@ -59,9 +59,9 @@ namespace Hybridizer.Runtime.CUDAImports
                 return dev;
             }
 
-            internal override void CopyObject(object param, IntPtr dev)
+            internal override void CopyObject(object param, IntPtr dev, bool skipMemcpy = false)
             {
-                if (directlyWrittenToBuffer == IntPtr.Zero)
+                if (!skipMemcpy && directlyWrittenToBuffer == IntPtr.Zero)
                 {
                     byte[] numArray = ms.ToArray();
                     var gcHandle = GCHandle.Alloc(numArray, GCHandleType.Pinned);

--- a/src/Marshalling/Internal/Cuda/Aggregated/Serializer/CUDAAggregatedSerializer.cs
+++ b/src/Marshalling/Internal/Cuda/Aggregated/Serializer/CUDAAggregatedSerializer.cs
@@ -28,7 +28,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 this.state = state;
             }
 
-            public override IntPtr InitialVisit(object param)
+            public override IntPtr InitialVisit(object param, bool skipMemcpy = false)
             {
                 if (param == null)
                     return IntPtr.Zero;
@@ -45,19 +45,21 @@ namespace Hybridizer.Runtime.CUDAImports
                 var allocator = state.createAllocator(param, sizeCalculator.totalSize);
                 //_allAllocators[new WeakReference(param)] = allocator;
                 state._currentAllocator = allocator;
-                IntPtr res = base.InitialVisit(param);
-                allocator.copyBuffer();
+                IntPtr res = base.InitialVisit(param, skipMemcpy);
+                if (!skipMemcpy)
+                    allocator.copyBuffer();
                 state.StreamSynchronize();
                 allocator.freeBuffer();
                 return res;
             }
 
-            protected override IntPtr SerializeObjectArray(object param, uint size)
+            protected override IntPtr SerializeObjectArray(object param, uint size, bool skipMemcpy = false)
             {
-                IntPtr[] numArray = DeepSerializeArray(param as Array);
+                IntPtr[] numArray = DeepSerializeArray(param as Array, skipMemcpy);
 
                 IntPtr dev = state._currentAllocator.allocate(param, size);
-                state._currentAllocator.cpy(dev, numArray, size);
+                if (!skipMemcpy)
+                    state._currentAllocator.cpy(dev, numArray, size);
                 return dev;
             }
 
@@ -66,7 +68,7 @@ namespace Hybridizer.Runtime.CUDAImports
             /// </summary>
             /// <param name="ap">Array of objects</param>
             /// <returns>an array of pointers pointing to native memory</returns>
-            protected override IntPtr[] DeepSerializeArray(Array ap)
+            protected override IntPtr[] DeepSerializeArray(Array ap, bool skipMemcpy = false)
             {
                 var numArray = new IntPtr[GetElementCount(ap)];
                 int num1 = 0;
@@ -82,21 +84,22 @@ namespace Hybridizer.Runtime.CUDAImports
                     }
                     else
                     {
-                        IntPtr num2 = VisitObject(key, IntPtr.Zero);
+                        IntPtr num2 = VisitObject(key, IntPtr.Zero, skipMemcpy);
                         numArray[num1++] = new IntPtr((long)num2);
                     }
                 }
                 return numArray;
             }
 
-            protected override IntPtr BinaryCopyArray(object param, uint size)
+            protected override IntPtr BinaryCopyArray(object param, uint size, bool skipMemcpy = false)
             {
                 IntPtr dev = state._currentAllocator.allocate(param, size);
-                state._currentAllocator.cpy(dev, param as Array, size);
+                if (!skipMemcpy)
+                    state._currentAllocator.cpy(dev, param as Array, size);
                 return dev;
             }
 
-            protected override IntPtr SerializeCustom(ICustomMarshalled customMarshalled)
+            protected override IntPtr SerializeCustom(ICustomMarshalled customMarshalled, bool skipMemcpy = false)
             {
                 throw new NotImplementedException();
             }

--- a/src/Marshalling/Internal/Cuda/Aggregated/SizeCalculator/CUDAAggregatedObjectSizeCalculator.cs
+++ b/src/Marshalling/Internal/Cuda/Aggregated/SizeCalculator/CUDAAggregatedObjectSizeCalculator.cs
@@ -91,7 +91,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 s.addSize(8);
             }
 
-            protected override void HandleObject(FieldTools.FieldDeclaration key, object param, IntPtr p)
+            protected override void HandleObject(FieldTools.FieldDeclaration key, object param, IntPtr p, bool skipMemcpy = false)
             {
                 IntPtr ptr = serializer.VisitObject(key.Info.GetValue(param), IntPtr.Zero);
                 HandlePtr(key, param, ptr);
@@ -137,7 +137,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 return IntPtr.Zero;
             }
 
-            internal override void CopyObject(object param, IntPtr dev)
+            internal override void CopyObject(object param, IntPtr dev, bool skipMemcpy = false)
             {
             }
         }

--- a/src/Marshalling/Internal/Cuda/Aggregated/SizeCalculator/CUDAAggregatedSizeCalculator.cs
+++ b/src/Marshalling/Internal/Cuda/Aggregated/SizeCalculator/CUDAAggregatedSizeCalculator.cs
@@ -46,7 +46,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 totalSize += size;
             }
 
-            protected override IntPtr SerializeObjectArray(object param, uint size)
+            protected override IntPtr SerializeObjectArray(object param, uint size, bool skipMemcpy = false)
             {
                 DeepSerializeArray(param as Array);
                 totalSize += size;
@@ -59,7 +59,7 @@ namespace Hybridizer.Runtime.CUDAImports
             /// </summary>
             /// <param name="ap">Array of objects</param>
             /// <returns>an array of pointers pointing to native memory</returns>
-            protected override IntPtr[] DeepSerializeArray(Array ap)
+            protected override IntPtr[] DeepSerializeArray(Array ap, bool skipMemcpy = false)
             {
                 foreach (object key in ap)
                 {
@@ -71,7 +71,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 return null;
             }
 
-            protected override IntPtr BinaryCopyArray(object param, uint size)
+            protected override IntPtr BinaryCopyArray(object param, uint size, bool skipMemcpy = false)
             {
                 if (size < MAX_SIZE_FOR_AGGREGATION)
                 {
@@ -81,13 +81,13 @@ namespace Hybridizer.Runtime.CUDAImports
                 return IntPtr.Zero;
             }
 
-            protected override IntPtr SerializeCustom(ICustomMarshalled o)
+            protected override IntPtr SerializeCustom(ICustomMarshalled o, bool skipMemcpy = false)
             {
                 totalSize += FieldTools.SizeOf(o.GetType());
                 return IntPtr.Zero;
             }
 
-            protected override IntPtr SerializeCustom(IHybCustomMarshaler marshaler, object customMarshalled)
+            protected override IntPtr SerializeCustom(IHybCustomMarshaler marshaler, object customMarshalled, bool skipMemcpy = false)
             {
                 totalSize += marshaler.SizeOf(customMarshalled);
                 pad64();
@@ -109,7 +109,7 @@ namespace Hybridizer.Runtime.CUDAImports
 
             }
 
-            protected override IntPtr WrapArray(Array array, IntPtr res)
+            protected override IntPtr WrapArray(Array array, IntPtr res, bool skipMemcpy = false)
             {
                 int rank = array.Rank;
                 totalSize += rank*8;

--- a/src/Marshalling/Internal/Cuda/CudaAbstractSerializationState.cs
+++ b/src/Marshalling/Internal/Cuda/CudaAbstractSerializationState.cs
@@ -91,7 +91,7 @@ namespace Hybridizer.Runtime.CUDAImports
                     cudaError_t err = cuda.Memcpy(dst, src, size, kind);
                     if (err != cudaError_t.cudaSuccess)
                     {
-                        throw new ApplicationException(String.Format("Error while copying data {0} : ", err, cuda.GetErrorString(err)));
+                        throw new ApplicationException( String.Format("Error while copying data {0} : {1}", err, cuda.GetErrorString(err)));
                     }
                 }
                 if (registerHost) cuda.HostUnregister(hostPtr);

--- a/src/Marshalling/Internal/Cuda/CudaSerializationState.cs
+++ b/src/Marshalling/Internal/Cuda/CudaSerializationState.cs
@@ -35,14 +35,14 @@ namespace Hybridizer.Runtime.CUDAImports
 
         #region CUDA Serialization
 
-        internal override void RemoveNative(IntPtr native)
+        internal override void RemoveNative(IntPtr native, bool skipMemcpy = false)
         {
             cudaError_t cuer = cuda.GetLastError();
             if (cuer != cudaError_t.cudaSuccess)
             {
                 throw new ApplicationException(String.Format("CUDA error {0} - unmarshalling impossible", cuer));
             }
-            base.RemoveNative(native);
+            base.RemoveNative(native, skipMemcpy);
         }
 
         internal override void RemoveObject(object p)
@@ -65,27 +65,29 @@ namespace Hybridizer.Runtime.CUDAImports
             {
             }
 
-            public override IntPtr InitialVisit(object param)
+            public override IntPtr InitialVisit(object param, bool skipMemcpy = false)
             {
                 CudaSerState.InitializeStream();
-                IntPtr res = base.InitialVisit(param);
+                IntPtr res = base.InitialVisit(param, skipMemcpy);
                 CudaSerState.StreamSynchronize();
                 return res;
             }
 
-            protected override IntPtr SerializeObjectArray(object param, uint size)
+            protected override IntPtr SerializeObjectArray(object param, uint size, bool skipMemcpy = false)
             {
                 IntPtr dev;
-                IntPtr[] numArray = DeepSerializeArray(param as Array);
-                var gcHandle = GCHandle.Alloc(numArray, GCHandleType.Pinned);
+                IntPtr[] numArray = DeepSerializeArray(param as Array, skipMemcpy);
                 if (CudaSerState.cuda.Malloc(out dev, size) != cudaError_t.cudaSuccess)
                     Logger.WriteLine("CUDA Error {0} Allocating {1} bytes", CudaSerState.cuda.GetLastError(), size);
 #if DEBUG_ALLOC
                 Logger.WriteLine("Allocated {1} bytes @{0:X} -- {2}", dev.ToInt64(), size, param.GetType().FullName);
 #endif
-                IntPtr src = Marshal.UnsafeAddrOfPinnedArrayElement(numArray, 0);
-
-                CudaSerState.CudaMemCopy(dev, src, size, cudaMemcpyKind.cudaMemcpyHostToDevice, gcHandle);
+                if (!skipMemcpy)
+                {
+                    var gcHandle = GCHandle.Alloc(numArray, GCHandleType.Pinned);
+                    IntPtr src = Marshal.UnsafeAddrOfPinnedArrayElement(numArray, 0);
+                    CudaSerState.CudaMemCopy(dev, src, size, cudaMemcpyKind.cudaMemcpyHostToDevice, gcHandle);
+                }
                 return dev;
             }
 
@@ -94,7 +96,7 @@ namespace Hybridizer.Runtime.CUDAImports
             /// </summary>
             /// <param name="ap">Array of objects</param>
             /// <returns>an array of pointers pointing to native memory</returns>
-            protected override IntPtr[] DeepSerializeArray(Array ap)
+            protected override IntPtr[] DeepSerializeArray(Array ap, bool skipMemcpy = false)
             {
                 var numArray = new IntPtr[GetElementCount(ap)];
                 int num1 = 0;
@@ -112,7 +114,7 @@ namespace Hybridizer.Runtime.CUDAImports
                         }
                         else
                         {
-                            IntPtr num2 = VisitObject(key, IntPtr.Zero);
+                            IntPtr num2 = VisitObject(key, IntPtr.Zero, skipMemcpy);
                             numArray[num1++] = new IntPtr((long)num2);
                         }
                     }
@@ -120,30 +122,9 @@ namespace Hybridizer.Runtime.CUDAImports
                 return numArray;
             }
 
-            protected override IntPtr BinaryCopyArray(object param, uint size)
+            protected override IntPtr BinaryCopyArray(object param, uint size, bool skipMemcpy = false)
             {
                 IntPtr dev;
-                IntPtr src = IntPtr.Zero;
-                bool blittable = true;
-                GCHandle handle = new GCHandle();
-                // in case of non-blittable data -> marshal by hand
-                try
-                {
-                    handle = GCHandle.Alloc(param, GCHandleType.Pinned);
-                    src = Marshal.UnsafeAddrOfPinnedArrayElement(param as Array, 0);
-                }
-                catch (ArgumentException)
-                {
-                    blittable = false;
-                }
-
-                if (!blittable)
-                {
-                    // in case of non-blittable data -> marshal by hand
-                    byte[] data = SerializeNonBlittableArray(param as Array) ;
-                    handle = GCHandle.Alloc(data, GCHandleType.Pinned);
-                    src = Marshal.UnsafeAddrOfPinnedArrayElement(data as Array, 0);
-                }
 
                 if (CudaSerState.cuda.Malloc(out dev, size) != cudaError_t.cudaSuccess)
                 {
@@ -161,19 +142,44 @@ namespace Hybridizer.Runtime.CUDAImports
                 Logger.WriteLine("Allocated {1} bytes @{0:X} -- {2}", dev.ToInt64(), size, param.GetType().FullName);
 #endif
 
-                CudaSerState.CudaMemCopy(dev, src, size, cudaMemcpyKind.cudaMemcpyHostToDevice, handle);
-                
+                if (!skipMemcpy)
+                {
+                    IntPtr src = IntPtr.Zero;
+                    bool blittable = true;
+                    GCHandle handle = new GCHandle();
+                    // in case of non-blittable data -> marshal by hand
+                    try
+                    {
+                        handle = GCHandle.Alloc(param, GCHandleType.Pinned);
+                        src = Marshal.UnsafeAddrOfPinnedArrayElement(param as Array, 0);
+                    }
+                    catch (ArgumentException)
+                    {
+                        blittable = false;
+                    }
+
+                    if (!blittable)
+                    {
+                        // in case of non-blittable data -> marshal by hand
+                        byte[] data = SerializeNonBlittableArray(param as Array) ;
+                        handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+                        src = Marshal.UnsafeAddrOfPinnedArrayElement(data as Array, 0);
+                    }
+
+                    CudaSerState.CudaMemCopy(dev, src, size, cudaMemcpyKind.cudaMemcpyHostToDevice, handle);
+                }
+
                 return dev;
             }
 
-            protected override IntPtr SerializeCustom(ICustomMarshalled customMarshalled)
+            protected override IntPtr SerializeCustom(ICustomMarshalled customMarshalled, bool skipMemcpy = false)
             {
                 var size = FieldTools.SizeOf(customMarshalled.GetType());
-                var buffer = new byte[size];    
+                var buffer = new byte[size];
                 var memoryStream = new MemoryStream(buffer);
                 var br = new BinaryWriter(memoryStream);
                 customMarshalled.MarshalTo(br, serState.nativePtrConverter.Flavor);
-                return BinaryCopyArray(buffer, (uint)size);
+                return BinaryCopyArray(buffer, (uint)size, skipMemcpy);
             }
 
             internal override void Free(IntPtr ptr)
@@ -238,13 +244,16 @@ namespace Hybridizer.Runtime.CUDAImports
                 return dev;
             }
 
-            internal override void CopyObject(object param, IntPtr dev)
+            internal override void CopyObject(object param, IntPtr dev, bool skipMemcpy = false)
             {
-                var size = (uint)ms.Length;
-                byte[] numArray = ms.ToArray();
-                var gcHandle = GCHandle.Alloc(numArray, GCHandleType.Pinned);
-                IntPtr src = Marshal.UnsafeAddrOfPinnedArrayElement(numArray, 0);
-                CudaSerState.CudaMemCopy(dev, src, size, cudaMemcpyKind.cudaMemcpyHostToDevice, gcHandle);
+                if (!skipMemcpy)
+                {
+                    var size = (uint)ms.Length;
+                    byte[] numArray = ms.ToArray();
+                    var gcHandle = GCHandle.Alloc(numArray, GCHandleType.Pinned);
+                    IntPtr src = Marshal.UnsafeAddrOfPinnedArrayElement(numArray, 0);
+                    CudaSerState.CudaMemCopy(dev, src, size, cudaMemcpyKind.cudaMemcpyHostToDevice, gcHandle);
+                }
             }
         }
 
@@ -261,14 +270,14 @@ namespace Hybridizer.Runtime.CUDAImports
             {
             }
 
-            protected override void DeserializeRawData(byte[] data, IntPtr da, long size)
+            protected override void DeserializeRawData(byte[] data, IntPtr da, long size, bool skipMemcpy = false)
             {
                 GCHandle gcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
                 CudaSerState.CudaMemCopy(Marshal.UnsafeAddrOfPinnedArrayElement(data, 0), da, size,
                             cudaMemcpyKind.cudaMemcpyDeviceToHost, gcHandle);
             }
 
-            protected override void DeserializeArray(object param, IntPtr da, Type type)
+            protected override void DeserializeArray(object param, IntPtr da, Type type, bool skipMemcpy = false)
             {
                 uint elementCount = GetElementCount(param as Array);
                 int size = (int) (SizeOfArrayElt(type.GetElementType()) * elementCount);
@@ -337,12 +346,12 @@ namespace Hybridizer.Runtime.CUDAImports
                 }
             }
 
-            public override IntPtr InitialVisit(object param)
+            public override IntPtr InitialVisit(object param, bool skipMemcpy = false)
             {
                 if (CUDAImports.cuda.GetPeekAtLastError() != cudaError_t.cudaSuccess)
                     throw new ApplicationException("CUDA error occured before deserialization (most probably during kernel call): " + CUDAImports.cuda.GetErrorString(CUDAImports.cuda.GetPeekAtLastError()));
                 CudaSerState.InitializeStream();
-                IntPtr res = base.InitialVisit(param);
+                IntPtr res = base.InitialVisit(param, skipMemcpy);
                 CudaSerState.StreamSynchronize();
                 return res;
             }
@@ -357,7 +366,7 @@ namespace Hybridizer.Runtime.CUDAImports
 
             private CudaAbstractSerializationState CudaSerState { get { return (CudaAbstractSerializationState)serState; } }
 
-            internal override void start(object param, Type type, IntPtr da)
+            internal override void start(object param, Type type, IntPtr da, bool skipMemcpy = false)
             {
                 uint size = (uint)FieldTools.SizeOf(type);
                 long expected = serState.nativePtrConverter.Convert(type).ToInt64();

--- a/src/Marshalling/Internal/MainMemory/MainMemorySerializationState.cs
+++ b/src/Marshalling/Internal/MainMemory/MainMemorySerializationState.cs
@@ -65,7 +65,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 this.state = state;
             }
 
-            protected override IntPtr SerializeObjectArray(object param, uint size)
+            protected override IntPtr SerializeObjectArray(object param, uint size, bool skipMemcpy = false)
             {
                 IntPtr[] numArray = DeepSerializeArray(param as Array);
                 var gcHandle = GCHandle.Alloc(numArray, GCHandleType.Pinned);
@@ -80,7 +80,7 @@ namespace Hybridizer.Runtime.CUDAImports
             /// </summary>
             /// <param name="ap">Array of objects</param>
             /// <returns>an array of pointers pointing to native memory</returns>
-            protected override IntPtr[] DeepSerializeArray(Array ap)
+            protected override IntPtr[] DeepSerializeArray(Array ap, bool skipMemcpy = false)
             {
                 var numArray = new IntPtr[GetElementCount(ap)];
                 int num1 = 0;
@@ -103,7 +103,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 return numArray;
             }
 
-            protected override IntPtr BinaryCopyArray(object param, uint size)
+            protected override IntPtr BinaryCopyArray(object param, uint size, bool skipMemcpy = false)
             {
                 bool blittable = true;
                 GCHandle handle = new GCHandle();
@@ -135,7 +135,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 return dev;
             }
 
-            protected override IntPtr SerializeCustom(ICustomMarshalled customMarshalled)
+            protected override IntPtr SerializeCustom(ICustomMarshalled customMarshalled, bool skipMemcpy = false)
             {
                 MainMemoryObjectSerializer os = new MainMemoryObjectSerializer(state, state.serializer);
                 os.MarshalICustomMarshalled(customMarshalled);
@@ -198,7 +198,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 return dev;
             }
 
-            internal override void CopyObject(object param, IntPtr dev)
+            internal override void CopyObject(object param, IntPtr dev, bool skipMemcpy = false)
             {
             }
         }
@@ -216,7 +216,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 this.state = state;
             }
 
-            protected override void DeserializeRawData(byte[] data, IntPtr da, long size)
+            protected override void DeserializeRawData(byte[] data, IntPtr da, long size, bool skipMemcpy = false)
             {
                 if(size > int.MaxValue) {
                     Console.WriteLine("WARNING : cannot yet deserialize more than 2GB of raw data");
@@ -224,7 +224,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 Marshal.Copy(da, data, 0, (int)size);
             }
 
-            protected override void DeserializeArray(object param, IntPtr da, Type type)
+            protected override void DeserializeArray(object param, IntPtr da, Type type, bool skipMemcpy = false)
             {
                 if (type.GetElementType().IsPrimitive || type.GetElementType().IsValueType)
                 {
@@ -291,7 +291,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 this.state = state;
             }
 
-            internal override void start(object param, Type type, IntPtr da)
+            internal override void start(object param, Type type, IntPtr da, bool skipMemcpy = false)
             {
                 var buffer = state.serialized_objects[param];
 

--- a/src/Marshalling/Internal/NativeDeserializer.cs
+++ b/src/Marshalling/Internal/NativeDeserializer.cs
@@ -26,7 +26,7 @@ namespace Hybridizer.Runtime.CUDAImports
             {
             }
 
-            public override IntPtr InitialVisit(object param)
+            public override IntPtr InitialVisit(object param, bool skipMemcpy = false)
             {
                 IntPtr dev;
                 if (param is Delegate) // Delegate as EntryPoint parameter
@@ -34,13 +34,13 @@ namespace Hybridizer.Runtime.CUDAImports
                     if (serState.cleanUpNativeData)
                     {
                         Delegate del = param as Delegate;
-                        InitialVisit(del.Target);
+                        InitialVisit(del.Target, skipMemcpy);
                     }
                     return IntPtr.Zero;
                 }
                 if (serState.ghosts.TryGetValue(param, out dev))
                 {
-                    return VisitObject(param, dev);
+                    return VisitObject(param, dev, skipMemcpy);
                 }
                 if (param is Array && CudaRuntimeProperties.UseHybridArrays)
                 {
@@ -56,20 +56,20 @@ namespace Hybridizer.Runtime.CUDAImports
                 return IntPtr.Zero;
             }
 
-            internal override IntPtr VisitObject(object param, IntPtr da)
+            internal override IntPtr VisitObject(object param, IntPtr da, bool skipMemcpy = false)
             {
-                VisitObjectInt(param, da);
+                VisitObjectInt(param, da, skipMemcpy);
                 return IntPtr.Zero;
             }
 
-            private void VisitObjectInt(object param, IntPtr da)
+            private void VisitObjectInt(object param, IntPtr da, bool skipMemcpy = false)
             {
                 if (param == null || !serState.ghosts.ContainsKey(param))
                     return;
                 Type type = param.GetType();
                 if (type.IsArray)
                 {
-                    DeserializeArray(param, da, type);
+                    DeserializeArray(param, da, type, skipMemcpy);
                     serState.RemoveObject(param);
                 }
                 else if (type == typeof (string))
@@ -85,7 +85,7 @@ namespace Hybridizer.Runtime.CUDAImports
                         // get size
                         long size = FieldTools.SizeOf(param.GetType());
                         byte[] data = new byte[size];
-                        DeserializeRawData(data, da, size);
+                        DeserializeRawData(data, da, size, skipMemcpy);
                         (param as ICustomMarshalled).UnmarshalFrom(new BinaryReader(new MemoryStream(data, false)), this.serState.nativePtrConverter.Flavor);
                         serState.RemoveObject(param);
                         return;
@@ -99,10 +99,10 @@ namespace Hybridizer.Runtime.CUDAImports
 
                     FieldVisitor fv = CreateFieldVisitor();
                     TypeInfo typeInfo = serState.nativePtrConverter.GetTypeInfo(type);
-                    fv.start(param, type, da);
-                    fv.VisitFields(param, typeInfo, overrides);
+                    fv.start(param, type, da, skipMemcpy);
+                    fv.VisitFields(param, typeInfo, overrides, skipMemcpy);
                     IntPtr ptr = fv.AllocateObject(param);
-                    fv.CopyObject(param, ptr);
+                    fv.CopyObject(param, ptr, skipMemcpy);
                 }
             }
 
@@ -119,9 +119,9 @@ namespace Hybridizer.Runtime.CUDAImports
                 }
             }
 
-            protected abstract void DeserializeArray(object param, IntPtr da, Type type);
+            protected abstract void DeserializeArray(object param, IntPtr da, Type type, bool skipMemcpy = false);
 
-            protected abstract void DeserializeRawData(byte[] data, IntPtr da, long size);
+            protected abstract void DeserializeRawData(byte[] data, IntPtr da, long size, bool skipMemcpy = false);
         }
     }
 }

--- a/src/Marshalling/Internal/NativeObjectDeserializer.cs
+++ b/src/Marshalling/Internal/NativeObjectDeserializer.cs
@@ -36,7 +36,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 return IntPtr.Zero;
             }
 
-            internal override void CopyObject(object param, IntPtr dev)
+            internal override void CopyObject(object param, IntPtr dev, bool skipMemcpy = false)
             {
             }
 
@@ -169,7 +169,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 }
             }
 
-            protected override void HandleObject(FieldTools.FieldDeclaration key, object param, IntPtr p)
+            protected override void HandleObject(FieldTools.FieldDeclaration key, object param, IntPtr p, bool skipMemcpy = false)
             {
 
                 object target = key.Info.GetValue(param);
@@ -178,7 +178,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 {
                     long readInt64 = Unpad64(br, false).ReadInt64();
                     IntPtr devP = new IntPtr(readInt64);
-                    IntPtr unused = deserializer.VisitObject(target, devP);
+                    IntPtr unused = deserializer.VisitObject(target, devP, skipMemcpy);
                     if (CudaRuntimeProperties.UseHybridArrays && target != null && target is Array)
                     {
                         // Advance in buffer to get rid of array dimensions
@@ -216,7 +216,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 }
             }
 
-            protected override void HandleDelegate(FieldTools.FieldDeclaration key, object param, IntPtr p)
+            protected override void HandleDelegate(FieldTools.FieldDeclaration key, object param, IntPtr p, bool skipMemcpy = false)
             {
                 if (key.Info.GetValue(param) != null)
                 {

--- a/src/Marshalling/Internal/NativeObjectSerializer.cs
+++ b/src/Marshalling/Internal/NativeObjectSerializer.cs
@@ -153,20 +153,20 @@ namespace Hybridizer.Runtime.CUDAImports
                 }
             }
 
-            protected override void HandleObject(FieldTools.FieldDeclaration key, object param, IntPtr p)
+            protected override void HandleObject(FieldTools.FieldDeclaration key, object param, IntPtr p, bool skipMemcpy = false)
             {
-                IntPtr ptr = serializer.VisitObject(key.Info.GetValue(param), IntPtr.Zero);
+                IntPtr ptr = serializer.VisitObject(key.Info.GetValue(param), IntPtr.Zero, skipMemcpy);
                 HandlePtr(key, param, ptr);
             }
-            
-            protected override void HandleDelegate(FieldTools.FieldDeclaration key, object param, IntPtr p)
+
+            protected override void HandleDelegate(FieldTools.FieldDeclaration key, object param, IntPtr p, bool skipMemcpy = false)
             {
                 if(key.Info.GetValue(param) != null) {
                     Delegate del = key.Info.GetValue(param) as Delegate;
                     IntPtr ptr = IntPtr.Zero;
                     if (param != del.Target)
                     {
-                        ptr = serializer.VisitObject(del.Target, IntPtr.Zero);
+                        ptr = serializer.VisitObject(del.Target, IntPtr.Zero, skipMemcpy);
                     }
                     else
                     {
@@ -222,7 +222,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 Pad64(bw);
             }
 
-            internal override void start(object param, Type type, IntPtr da)
+            internal override void start(object param, Type type, IntPtr da, bool skipMemcpy = false)
             {
             }
         }

--- a/src/Marshalling/Internal/NativeSerializer.cs
+++ b/src/Marshalling/Internal/NativeSerializer.cs
@@ -54,7 +54,7 @@ namespace Hybridizer.Runtime.CUDAImports
                     return IntPtr.Zero ;
                 }
 
-                internal override void CopyObject(object param, IntPtr dev)
+                internal override void CopyObject(object param, IntPtr dev, bool skipMemcpy = false)
                 {
                 }
 
@@ -70,7 +70,7 @@ namespace Hybridizer.Runtime.CUDAImports
                     : base(state, ser)
                 { }
 
-                internal override void start(object param, Type type, IntPtr da)
+                internal override void start(object param, Type type, IntPtr da, bool skipMemcpy = false)
                 {
                 }
 
@@ -108,7 +108,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 return bytes;
             }
 
-            public override IntPtr InitialVisit(object param)
+            public override IntPtr InitialVisit(object param, bool skipMemcpy = false)
             {
                 if (typeof(ICustomMarshalled).IsAssignableFrom(param.GetType()) && param.GetType().IsValueType)
                 {
@@ -120,11 +120,11 @@ namespace Hybridizer.Runtime.CUDAImports
                     IntPtr ptr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
                     serState.directlyMappedArrayPtr[param] = ptr;
                     return ptr;
-                } 
+                }
                 else if (param is Delegate) // Delegate as EntryPoint parameter
                 {
                     Delegate del = param as Delegate;
-                    IntPtr target = serState.serializer.VisitObject(del.Target, IntPtr.Zero);
+                    IntPtr target = serState.serializer.VisitObject(del.Target, IntPtr.Zero, skipMemcpy);
                     IntPtr fPtr = serState.nativePtrConverter.GetFunctionPointer(del.Method);
 
                     byte[] buffer = new byte[24];
@@ -139,7 +139,7 @@ namespace Hybridizer.Runtime.CUDAImports
                     serState.directlyMappedArrayPtr[del] = ptr;
                     return ptr;
                 }
-                IntPtr res = VisitObject(param, IntPtr.Zero);
+                IntPtr res = VisitObject(param, IntPtr.Zero, skipMemcpy);
                 if (param is Array && CudaRuntimeProperties.UseHybridArrays)
                 {
                     // Pass a ptr to a hybarray struct in CPU memory
@@ -149,7 +149,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 return res;
             }
 
-            protected virtual IntPtr WrapArray(Array array, IntPtr res)
+            protected virtual IntPtr WrapArray(Array array, IntPtr res, bool skipMemcpy = false)
             {
                 int rank = array.Rank;
                 byte[] buffer = new byte[8 + 8 * rank]; // 8 bytes for the ptr + 8 bytes per dimension (length and lowerbound)
@@ -163,7 +163,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 return ptr;
             }
             
-            internal unsafe override IntPtr VisitObject(object param, IntPtr da)
+            internal unsafe override IntPtr VisitObject(object param, IntPtr da, bool skipMemcpy = false)
             {
                 if (param == null)
                     return IntPtr.Zero;
@@ -172,7 +172,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 Type type = param.GetType();
                 if (typeof (ICustomMarshalled).IsAssignableFrom(type))
                 {
-                    IntPtr result = SerializeCustom(param as ICustomMarshalled);
+                    IntPtr result = SerializeCustom(param as ICustomMarshalled, skipMemcpy);
                     AddGhost(param, result);
                     return result;
                 }
@@ -188,11 +188,11 @@ namespace Hybridizer.Runtime.CUDAImports
                     uint size = SizeOfArrayElt(array.GetType().GetElementType()) * elementCount;
                     if (array.GetType().GetElementType().IsPrimitive || array.GetType().GetElementType().IsValueType)
                     {
-                        dev = BinaryCopyArray(array, size);
+                        dev = BinaryCopyArray(array, size, skipMemcpy);
                     }
                     else
                     {
-                        dev = SerializeObjectArray(array, size);
+                        dev = SerializeObjectArray(array, size, skipMemcpy);
                     }
 
                     AddGhost(param, dev);
@@ -202,15 +202,15 @@ namespace Hybridizer.Runtime.CUDAImports
                     return dev;
                 }
                 else if (typeof(Delegate).IsAssignableFrom(type))
-                { 
+                {
                     Delegate del = param as Delegate;
                     if (del == null)
                         throw new ApplicationException("INTERNAL ERROR - expecting delegate");
                     // delegates are arrays of two intptr
-                    IntPtr target = serState.serializer.VisitObject(del.Target, IntPtr.Zero);
+                    IntPtr target = serState.serializer.VisitObject(del.Target, IntPtr.Zero, skipMemcpy);
                     IntPtr fPtr = serState.nativePtrConverter.GetFunctionPointer(del.Method);
-                    IntPtr dev = BinaryCopyArray(new long[]{target.ToInt64(), fPtr.ToInt64(), 0L}, SizeOfArrayElt(typeof(long)) * 3) ;
-                    AddGhost(param, dev); 
+                    IntPtr dev = BinaryCopyArray(new long[]{target.ToInt64(), fPtr.ToInt64(), 0L}, SizeOfArrayElt(typeof(long)) * 3, skipMemcpy) ;
+                    AddGhost(param, dev);
                     return dev;
                 }
                 else
@@ -232,12 +232,12 @@ namespace Hybridizer.Runtime.CUDAImports
                     TypeInfo ti = serState.nativePtrConverter.GetTypeInfo(type);
                     if (ti.CustomMarshaler != null)
                     {
-                        return SerializeCustom(ti.CustomMarshaler, param);
+                        return SerializeCustom(ti.CustomMarshaler, param, skipMemcpy);
                     }
- 
+
                     FieldVisitor fv = CreateFieldVisitor();
-                    fv.start(param, type, da);
-                    fv.VisitFields(param, ti, overrides);
+                    fv.start(param, type, da, skipMemcpy);
+                    fv.VisitFields(param, ti, overrides, skipMemcpy);
                     IntPtr dev = fv.AllocateObject(param);
                     foreach (var pending in fv.pendingDelegateTargets)
                     {
@@ -247,7 +247,7 @@ namespace Hybridizer.Runtime.CUDAImports
                         pending.binaryWriter.Write(dev.ToInt64());
                         pending.binaryWriter.Seek((int)oldPosition, SeekOrigin.Begin);
                     }
-                    fv.CopyObject(param, dev);
+                    fv.CopyObject(param, dev, skipMemcpy);
 #if DEBUG_ALLOC
                     Logger.WriteLine("Object {0} serialized to {1:X}", param, dev.ToInt64());
 #endif
@@ -263,18 +263,18 @@ namespace Hybridizer.Runtime.CUDAImports
             protected abstract void SerializeResidentArray(Type type, Dictionary<FieldInfo, byte[]> overrides,
                 IResidentArray residentArray);
 
-            protected abstract IntPtr SerializeObjectArray(object param, uint size);
-            protected abstract IntPtr[] DeepSerializeArray(Array ap);
-            protected abstract IntPtr BinaryCopyArray(object param, uint size);
-            protected abstract IntPtr SerializeCustom(ICustomMarshalled customMarshalled);
-            protected virtual IntPtr SerializeCustom(IHybCustomMarshaler marshaler, object customMarshalled)
+            protected abstract IntPtr SerializeObjectArray(object param, uint size, bool skipMemcpy = false);
+            protected abstract IntPtr[] DeepSerializeArray(Array ap, bool skipMemcpy = false);
+            protected abstract IntPtr BinaryCopyArray(object param, uint size, bool skipMemcpy = false);
+            protected abstract IntPtr SerializeCustom(ICustomMarshalled customMarshalled, bool skipMemcpy = false);
+            protected virtual IntPtr SerializeCustom(IHybCustomMarshaler marshaler, object customMarshalled, bool skipMemcpy = false)
             {
                 var size = marshaler.SizeOf(customMarshalled);
                 var buffer = new byte[size];
                 var memoryStream = new MemoryStream(buffer);
                 var br = new BinaryWriter(memoryStream);
                 marshaler.MarshalTo(customMarshalled, br, serState.Marshaler);
-                return BinaryCopyArray(buffer, (uint)size);
+                return BinaryCopyArray(buffer, (uint)size, skipMemcpy);
             }
         }
     }

--- a/src/Marshalling/Internal/NativeSerializerState.cs
+++ b/src/Marshalling/Internal/NativeSerializerState.cs
@@ -58,16 +58,23 @@ namespace Hybridizer.Runtime.CUDAImports
             this.CreatingThreadId = Thread.CurrentThread.Name;
         }
 
-        internal virtual IntPtr MarshalManagedToNative(object param)
+        internal virtual IntPtr MarshalManagedToNative(object param, bool skipMemcpy = false)
         {
-            return serializer.InitialVisit(param);
+            return serializer.InitialVisit(param, skipMemcpy);
         }
 
-        internal void UpdateManagedData(object param)
+        internal void UpdateManagedData(object param, bool skipMemcpy = false)
         {
             try
             {
-                deserializer.InitialVisit(param);
+                if (skipMemcpy)
+                {
+                    FreeObjectGraph(param);
+                }
+                else
+                {
+                    deserializer.InitialVisit(param);
+                }
             }
             catch (Exception ex)
             {
@@ -76,10 +83,10 @@ namespace Hybridizer.Runtime.CUDAImports
             }
         }
 
-        internal virtual void RemoveNative(IntPtr native)
+        internal virtual void RemoveNative(IntPtr native, bool skipMemcpy = false)
         {
             // Console.WriteLine("Remove native thread:{0} marshaller:{1}", Thread.CurrentThread.Name, this.CreatingThreadId);
-            
+
             try
             {
                 object managed = null;
@@ -104,7 +111,14 @@ namespace Hybridizer.Runtime.CUDAImports
                 }
                 if (managed == null) return;
 
-                deserializer.InitialVisit(managed);
+                if (skipMemcpy)
+                {
+                    FreeObjectGraph(managed);
+                }
+                else
+                {
+                    deserializer.InitialVisit(managed);
+                }
             }
             catch (Exception ex)
             {
@@ -124,7 +138,7 @@ namespace Hybridizer.Runtime.CUDAImports
             ghosts.Clear();
         }
 
-        internal IntPtr MarshalNonPrimitiveParameter(Type t, object param)
+        internal IntPtr MarshalNonPrimitiveParameter(Type t, object param, bool skipMemcpy = false)
         {
             try
             {
@@ -132,7 +146,7 @@ namespace Hybridizer.Runtime.CUDAImports
                     throw new NotSupportedException(string.Format("Type {0} is not supported for marshalling", t.FullName));
                 if (param == null)
                     return IntPtr.Zero;
-                return MarshalManagedToNative(param);
+                return MarshalManagedToNative(param, skipMemcpy);
             }
             catch (Exception ex)
             {
@@ -164,6 +178,46 @@ namespace Hybridizer.Runtime.CUDAImports
         internal virtual void RemoveObject(object p)
         {
             if (p != null) ghosts.Remove(p);
+        }
+
+        internal void FreeObjectGraph(object param)
+        {
+            if (param == null) return;
+            if (!ghosts.ContainsKey(param)) return;
+
+            Type type = param.GetType();
+            if (type.IsArray)
+            {
+                Type elemType = type.GetElementType();
+                if (!elemType.IsPrimitive && !elemType.IsValueType)
+                {
+                    foreach (object elem in (Array)param)
+                        FreeObjectGraph(elem);
+                }
+            }
+            else if (type.IsClass || type.IsInterface)
+            {
+                foreach (var fd in OrderedFields(type))
+                {
+                    if (fd.Info == null) continue;
+                    if (fd.FieldType.IsArray || fd.FieldType.IsClass || fd.FieldType.IsInterface)
+                    {
+                        object subObj = fd.Info.GetValue(param);
+                        FreeObjectGraph(subObj);
+                    }
+                }
+            }
+
+            // Also clean up directlyMappedArrayHandles if present
+            GCHandle handle;
+            if (directlyMappedArrayHandles.TryGetValue(param, out handle))
+            {
+                handle.Free();
+                directlyMappedArrayPtr.Remove(param);
+                directlyMappedArrayHandles.Remove(param);
+            }
+
+            RemoveObject(param);
         }
 
         internal static void WriteHybArrayDimensions(Array array, int rank, BinaryWriter bw)

--- a/src/Marshalling/Shared/AbstractNativeMarshaler.cs
+++ b/src/Marshalling/Shared/AbstractNativeMarshaler.cs
@@ -144,6 +144,14 @@ namespace Hybridizer.Runtime.CUDAImports
         /// </summary>
         public virtual IntPtr MarshalManagedToNative(object managedObj)
         {
+            return MarshalManagedToNative(managedObj, false);
+        }
+
+        /// <summary>
+        /// Marshals Managed to Native, optionally skipping memcpy (allocation only)
+        /// </summary>
+        public virtual IntPtr MarshalManagedToNative(object managedObj, bool skipMemcpy)
+        {
             if (managedObj == null)
                 return IntPtr.Zero;
             Stopwatch sw = null;
@@ -159,7 +167,7 @@ namespace Hybridizer.Runtime.CUDAImports
                 return union._intPtr;
             }
 
-            IntPtr nativePtr = state.MarshalNonPrimitiveParameter(managedObj.GetType(), managedObj);
+            IntPtr nativePtr = state.MarshalNonPrimitiveParameter(managedObj.GetType(), managedObj, skipMemcpy);
             if (Debugger.IsAttached)
             {
                 sw.Stop();
@@ -173,8 +181,16 @@ namespace Hybridizer.Runtime.CUDAImports
         /// </summary>
         public void CleanUpNativeData(IntPtr pNativeData)
         {
+            CleanUpNativeData(pNativeData, false);
+        }
+
+        /// <summary>
+        /// cleanup native data, optionally skipping memcpy (free only)
+        /// </summary>
+        public void CleanUpNativeData(IntPtr pNativeData, bool skipMemcpy)
+        {
             if (!cleanUpNativeData) return;
-            state.RemoveNative(pNativeData);
+            state.RemoveNative(pNativeData, skipMemcpy);
         }
 
         /// <summary>
@@ -182,7 +198,15 @@ namespace Hybridizer.Runtime.CUDAImports
         /// </summary>
         public void CleanUpManagedData(object managedObj)
         {
-            state.UpdateManagedData(managedObj);
+            CleanUpManagedData(managedObj, false);
+        }
+
+        /// <summary>
+        /// cleanup managed data, optionally skipping memcpy (free only)
+        /// </summary>
+        public void CleanUpManagedData(object managedObj, bool skipMemcpy)
+        {
+            state.UpdateManagedData(managedObj, skipMemcpy);
         }
 
         /// <summary>

--- a/src/Marshalling/Shared/FieldVisitor.cs
+++ b/src/Marshalling/Shared/FieldVisitor.cs
@@ -19,17 +19,17 @@ namespace Hybridizer.Runtime.CUDAImports
 {
     abstract class FieldVisitor
     {
-        internal void VisitFields(object param, TypeInfo typeInfo, Dictionary<FieldInfo, byte[]> overrides)
+        internal void VisitFields(object param, TypeInfo typeInfo, Dictionary<FieldInfo, byte[]> overrides, bool skipMemcpy = false)
         {
             foreach (FieldTools.FieldDeclaration key in typeInfo.fields)
             {
-                HandleField(typeInfo, key, param, overrides);
+                HandleField(typeInfo, key, param, overrides, skipMemcpy);
             }
 
             HandleEndOfObject(param);
         }
 
-        void HandleField(TypeInfo typeInfo, FieldTools.FieldDeclaration key, object param, Dictionary<FieldInfo, byte[]> overrides)
+        void HandleField(TypeInfo typeInfo, FieldTools.FieldDeclaration key, object param, Dictionary<FieldInfo, byte[]> overrides, bool skipMemcpy = false)
         {
             bool hasOverride = overrides.Count > 0;
             if (typeInfo.type.IsGenericType && typeInfo.type.GetGenericTypeDefinition() == typeof(Nullable<>))
@@ -70,7 +70,7 @@ namespace Hybridizer.Runtime.CUDAImports
                             ++fdindex;
                         }
 
-                        HandleField(typeInfo, key.UnionSubFields[maxindex], param, overrides);
+                        HandleField(typeInfo, key.UnionSubFields[maxindex], param, overrides, skipMemcpy);
                     }
                     else if (hasOverride && overrides.ContainsKey(key.Info))
                     {
@@ -100,9 +100,9 @@ namespace Hybridizer.Runtime.CUDAImports
                         if (!key.FieldType.IsArray && !key.FieldType.IsClass && !key.FieldType.IsInterface)
                             throw new NotImplementedException();
                         if (typeof(Delegate).IsAssignableFrom(key.FieldType))
-                            HandleDelegate(key, param, IntPtr.Zero);
+                            HandleDelegate(key, param, IntPtr.Zero, skipMemcpy);
                         else
-                            HandleObject(key, param, IntPtr.Zero);
+                            HandleObject(key, param, IntPtr.Zero, skipMemcpy);
                     }
                     break;
             }
@@ -126,13 +126,13 @@ namespace Hybridizer.Runtime.CUDAImports
         protected abstract void HandlePaddingByte(long count);
         protected abstract void HandleOverride(byte[] data);
         protected abstract void HandlePrimitive(FieldTools.FieldDeclaration key, object o);
-        protected abstract void HandleObject(FieldTools.FieldDeclaration key, object param, IntPtr p);
-        protected abstract void HandleDelegate(FieldTools.FieldDeclaration key, object param, IntPtr p);
+        protected abstract void HandleObject(FieldTools.FieldDeclaration key, object param, IntPtr p, bool skipMemcpy = false);
+        protected abstract void HandleDelegate(FieldTools.FieldDeclaration key, object param, IntPtr p, bool skipMemcpy = false);
         protected abstract void HandlePtr(FieldTools.FieldDeclaration key, object param, IntPtr o, bool isResidentArray = false);
         protected abstract void HandleValueType(FieldTools.FieldDeclaration key, object o, Dictionary<FieldInfo, byte[]> overrides);
         protected abstract void HandleEndOfObject(object param);
         internal abstract IntPtr AllocateObject(object param);
-        internal abstract void CopyObject(object param, IntPtr dev);
-        internal abstract void start(object param, Type type, IntPtr da);
+        internal abstract void CopyObject(object param, IntPtr dev, bool skipMemcpy = false);
+        internal abstract void start(object param, Type type, IntPtr da, bool skipMemcpy = false);
     }
 }

--- a/tests/HybRunnerInOutILTests.cs
+++ b/tests/HybRunnerInOutILTests.cs
@@ -1,0 +1,587 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using Hybridizer.Runtime.CUDAImports;
+
+namespace Hybridizer.Runtime.CUDAImports.Tests;
+
+/// <summary>
+/// Tests that HybRunner generates correct IL for [In]/[Out] parameter attributes.
+/// Creates a minimal stub .so, uses HybRunner.OMP to wrap test targets,
+/// then inspects the generated IL byte arrays.
+/// </summary>
+[TestFixture]
+public class HybRunnerInOutILTests
+{
+    private static string _stubDir;
+    private static string _stubPath;
+    private static HybRunner _runner;
+
+    private const byte LDC_I4_1 = 0x17;
+    private const byte CALL = 0x28;
+
+    private const string StubSource = @"
+#include <string.h>
+
+/*
+ * Must match C# HybridizerProperties which has [StructLayout(LayoutKind.Explicit, Size = 16)]
+ * but also a _dummy field at [FieldOffset(16)], making the actual CLR struct 20 bytes.
+ * On x86-64 Linux, structs > 16 bytes use sret (hidden pointer) calling convention.
+ */
+typedef struct {
+    int useHybridArrays;   /* offset 0 */
+    int flavor;            /* offset 4 */
+    int delegateSupport;   /* offset 8 */
+    int compatibilityMode; /* offset 12 */
+    int dummy;             /* offset 16 -- matches C# _dummy field */
+} HybridizerProperties;
+
+HybridizerProperties __HybridizerGetProperties(void) {
+    HybridizerProperties p;
+    memset(&p, 0, sizeof(p));
+    p.flavor = 2; /* OMP */
+    return p;
+}
+
+int HybridizerGetTypeID(const char* name) {
+    return 0;
+}
+
+int HybridizerGetShallowSize(const char* name) {
+    return 0;
+}
+";
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            Assert.Ignore("These tests require Linux (dlopen-based HybRunner)");
+
+        _stubDir = Path.Combine(Path.GetTempPath(), "hybrunner_il_tests_" + Guid.NewGuid().ToString("N").Substring(0, 8));
+        Directory.CreateDirectory(_stubDir);
+
+        string stubSourcePath = Path.Combine(_stubDir, "hybstub.c");
+        File.WriteAllText(stubSourcePath, StubSource);
+
+        _stubPath = Path.Combine(_stubDir, "hybstub.so");
+        var psi = new ProcessStartInfo("gcc", $"-shared -fPIC -o \"{_stubPath}\" \"{stubSourcePath}\"")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+
+        Process proc;
+        try
+        {
+            proc = Process.Start(psi);
+        }
+        catch (Exception ex)
+        {
+            Assert.Ignore("gcc not available: " + ex.Message);
+            return;
+        }
+
+        proc.WaitForExit(15000);
+        if (proc.ExitCode != 0)
+        {
+            string stderr = proc.StandardError.ReadToEnd();
+            Assert.Ignore("gcc compilation failed: " + stderr);
+            return;
+        }
+
+        _runner = HybRunner.OMP(_stubPath);
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        try
+        {
+            if (_stubDir != null && Directory.Exists(_stubDir))
+                Directory.Delete(_stubDir, true);
+        }
+        catch { /* best effort cleanup */ }
+    }
+
+    #region Helpers
+
+    private static MethodInfo GetWrappedProcessMethod(object target)
+    {
+        dynamic wrapped = _runner.Wrap(target);
+        Type wrappedType = ((object)wrapped).GetType();
+        // Find the "Process" method that takes managed parameters (not the IntPtr overload)
+        return wrappedType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => m.Name == "Process")
+            .Where(m => !m.GetParameters().Any(p => p.ParameterType == typeof(IntPtr)))
+            .First();
+    }
+
+    private static byte[] GetWrappedProcessIL(object target)
+    {
+        var method = GetWrappedProcessMethod(target);
+        var body = method.GetMethodBody();
+        Assert.That(body, Is.Not.Null, "GetMethodBody() returned null on dynamic method");
+        return body.GetILAsByteArray();
+    }
+
+    /// <summary>
+    /// Counts ldc.i4.1 (0x17) instructions by properly walking the IL instruction stream,
+    /// so operand bytes are not mistaken for opcodes.
+    /// </summary>
+    private static int CountLdcI4_1(byte[] il)
+    {
+        int count = 0;
+        int pos = 0;
+        while (pos < il.Length)
+        {
+            byte op = il[pos];
+            if (op == LDC_I4_1)
+                count++;
+            pos += GetInstructionSize(il, pos);
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Returns the total size (opcode + operand) of the IL instruction at the given offset.
+    /// Handles the opcodes commonly emitted by HybRunner's IL generation.
+    /// </summary>
+    private static int GetInstructionSize(byte[] il, int offset)
+    {
+        if (offset >= il.Length) return 1;
+        byte op = il[offset];
+
+        // Two-byte opcode prefix
+        if (op == 0xFE)
+        {
+            if (offset + 1 >= il.Length) return 1;
+            byte op2 = il[offset + 1];
+            // ceq(0x01), cgt(0x02), clt(0x04) — no operand
+            if (op2 <= 0x06) return 2;
+            // ldarg(0x09), starg(0x0B), ldloc(0x0C), stloc(0x0E), ldloca(0x0D) — 2-byte operand
+            if (op2 >= 0x09 && op2 <= 0x0E) return 4;
+            return 2; // conservative default for unknown 0xFE opcodes
+        }
+
+        switch (op)
+        {
+            // 1-byte instructions (no operand)
+            case 0x00: // nop
+            case 0x01: // break
+            case 0x02: case 0x03: case 0x04: case 0x05: // ldarg.0-3
+            case 0x06: case 0x07: case 0x08: case 0x09: // ldloc.0-3
+            case 0x0A: case 0x0B: case 0x0C: case 0x0D: // stloc.0-3
+            case 0x14: // ldnull
+            case 0x15: // ldc.i4.m1
+            case 0x16: case 0x17: case 0x18: case 0x19: // ldc.i4.0-3
+            case 0x1A: case 0x1B: case 0x1C: case 0x1D: case 0x1E: // ldc.i4.4-8
+            case 0x25: // dup
+            case 0x26: // pop
+            case 0x2A: // ret
+            case 0x58: case 0x59: case 0x5A: case 0x5B: // add, sub, mul, div
+            case 0x5C: case 0x5D: // div.un, rem
+            case 0x60: case 0x61: case 0x62: // and, or, xor
+            case 0x67: // conv.i1
+            case 0x68: // conv.i2
+            case 0x69: // conv.i4
+            case 0x6A: // conv.i8
+            case 0x6B: // conv.r4
+            case 0x6C: // conv.r8
+            case 0x6D: // conv.u4
+            case 0x6E: // conv.u8
+            case 0x76: // conv.r.un
+            case 0xD3: // conv.u
+                return 1;
+
+            // 2-byte instructions (1-byte operand)
+            case 0x0E: // ldarg.s
+            case 0x0F: // ldarga.s
+            case 0x10: // starg.s
+            case 0x11: // ldloc.s
+            case 0x12: // ldloca.s
+            case 0x13: // stloc.s
+            case 0x1F: // ldc.i4.s
+            case 0x2B: // br.s
+            case 0x2C: // brfalse.s
+            case 0x2D: // brtrue.s
+            case 0x2E: case 0x2F: case 0x30: case 0x31: // beq.s, bge.s, bgt.s, ble.s
+            case 0x32: case 0x33: case 0x34: case 0x35: // blt.s, bne.un.s, bge.un.s, bgt.un.s
+            case 0x36: case 0x37: // ble.un.s, blt.un.s
+            case 0xDE: // leave.s
+                return 2;
+
+            // 5-byte instructions (4-byte operand: tokens, int32, branch targets)
+            case 0x20: // ldc.i4
+            case 0x28: // call
+            case 0x29: // calli
+            case 0x38: // br
+            case 0x39: // brfalse
+            case 0x3A: // brtrue
+            case 0x3B: case 0x3C: case 0x3D: case 0x3E: // beq, bge, bgt, ble
+            case 0x3F: case 0x40: case 0x41: case 0x42: // blt, bne.un, bge.un, bgt.un
+            case 0x43: case 0x44: // ble.un, blt.un
+            case 0x6F: // callvirt
+            case 0x70: // cpobj
+            case 0x71: // ldobj
+            case 0x72: // ldstr
+            case 0x73: // newobj
+            case 0x74: // castclass
+            case 0x75: // isinst
+            case 0x79: // unbox
+            case 0x7B: // ldfld
+            case 0x7C: // ldflda
+            case 0x7D: // stfld
+            case 0x7E: // ldsfld
+            case 0x7F: // ldsflda
+            case 0x80: // stsfld
+            case 0x81: // stobj
+            case 0x8C: // box
+            case 0x8D: // newarr
+            case 0x8E: // ldlen (actually 1 byte, but harmless to overcount)
+            case 0xA1: // ldelema
+            case 0xA3: // ldelem
+            case 0xA4: // stelem
+            case 0xA5: // unbox.any
+            case 0xC2: // refanyval
+            case 0xC6: // mkrefany
+            case 0xD0: // ldtoken
+            case 0xDD: // leave
+                return 5;
+
+            // 9-byte instructions (8-byte operand)
+            case 0x21: // ldc.i8
+            case 0x23: // ldc.r8
+                return 9;
+
+            // 5-byte instructions (4-byte operand: float32)
+            case 0x22: // ldc.r4
+                return 5;
+
+            // switch (variable length)
+            case 0x45:
+            {
+                if (offset + 4 >= il.Length) return 5;
+                int count = BitConverter.ToInt32(il, offset + 1);
+                return 5 + count * 4;
+            }
+
+            default:
+                return 1; // unknown opcode, advance by 1
+        }
+    }
+
+    /// <summary>
+    /// Attempts to resolve Call instruction targets in the generated IL.
+    /// Returns null if Module.ResolveMethod doesn't work on dynamic modules.
+    /// </summary>
+    private static List<MethodBase> TryResolveCallTargets(MethodInfo method)
+    {
+        try
+        {
+            var body = method.GetMethodBody();
+            if (body == null) return null;
+            var il = body.GetILAsByteArray();
+            if (il == null) return null;
+            var module = method.Module;
+            var results = new List<MethodBase>();
+
+            int pos = 0;
+            while (pos < il.Length)
+            {
+                byte op = il[pos];
+                int size = GetInstructionSize(il, pos);
+                if (op == CALL && pos + 4 < il.Length)
+                {
+                    int token = BitConverter.ToInt32(il, pos + 1);
+                    try
+                    {
+                        var target = module.ResolveMethod(token);
+                        results.Add(target);
+                    }
+                    catch
+                    {
+                        return null;
+                    }
+                }
+                pos += size;
+            }
+            return results;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    #endregion
+
+    #region ldc.i4.1 count tests
+
+    [Test]
+    public void NoAttributes_NoSkipInstructions()
+    {
+        var il = GetWrappedProcessIL(new NoAttributeTarget());
+        Assert.That(CountLdcI4_1(il), Is.EqualTo(0),
+            "No attributes should produce zero ldc.i4.1 (no skip logic)");
+    }
+
+    [Test]
+    public void InOnly_OneSkipInstruction()
+    {
+        var il = GetWrappedProcessIL(new InOnlyTarget());
+        Assert.That(CountLdcI4_1(il), Is.EqualTo(1),
+            "[In]-only should produce exactly one ldc.i4.1 (cleanup skip)");
+    }
+
+    [Test]
+    public void OutOnly_OneSkipInstruction()
+    {
+        var il = GetWrappedProcessIL(new OutOnlyTarget());
+        Assert.That(CountLdcI4_1(il), Is.EqualTo(1),
+            "[Out]-only should produce exactly one ldc.i4.1 (marshal skip)");
+    }
+
+    [Test]
+    public void InOut_NoSkipInstructions()
+    {
+        var il = GetWrappedProcessIL(new InOutTarget());
+        Assert.That(CountLdcI4_1(il), Is.EqualTo(0),
+            "[In,Out] should produce zero ldc.i4.1 (no skip on either side)");
+    }
+
+    [Test]
+    public void MixedParams_CorrectSkipCount()
+    {
+        var il = GetWrappedProcessIL(new MixedTarget());
+        Assert.That(CountLdcI4_1(il), Is.EqualTo(2),
+            "Mixed [In]/[Out]/none should produce exactly 2 ldc.i4.1");
+    }
+
+    [Test]
+    public void InOut_SameSkipCountAs_NoAttributes()
+    {
+        var ilNoAttr = GetWrappedProcessIL(new NoAttributeTarget());
+        var ilInOut = GetWrappedProcessIL(new InOutTarget());
+        Assert.That(CountLdcI4_1(ilInOut), Is.EqualTo(CountLdcI4_1(ilNoAttr)),
+            "[In,Out] should produce same skip count as no-attribute");
+    }
+
+    [Test]
+    public void StaticMethod_InOnly_OneSkipInstruction()
+    {
+        var il = GetWrappedProcessIL(new StaticInOnlyTarget());
+        Assert.That(CountLdcI4_1(il), Is.EqualTo(1),
+            "Static [In]-only should produce exactly one ldc.i4.1");
+    }
+
+    #endregion
+
+    #region Parameter attribute preservation
+
+    [Test]
+    public void InOnly_PreservesIsIn()
+    {
+        var param = GetWrappedProcessMethod(new InOnlyTarget()).GetParameters()[0];
+        Assert.That(param.IsIn, Is.True);
+        Assert.That(param.IsOut, Is.False);
+    }
+
+    [Test]
+    public void OutOnly_PreservesIsOut()
+    {
+        var param = GetWrappedProcessMethod(new OutOnlyTarget()).GetParameters()[0];
+        Assert.That(param.IsOut, Is.True);
+        Assert.That(param.IsIn, Is.False);
+    }
+
+    [Test]
+    public void InOut_PreservesBoth()
+    {
+        var param = GetWrappedProcessMethod(new InOutTarget()).GetParameters()[0];
+        Assert.That(param.IsIn, Is.True);
+        Assert.That(param.IsOut, Is.True);
+    }
+
+    [Test]
+    public void NoAttributes_PreservesNone()
+    {
+        var param = GetWrappedProcessMethod(new NoAttributeTarget()).GetParameters()[0];
+        Assert.That(param.IsIn, Is.False);
+        Assert.That(param.IsOut, Is.False);
+    }
+
+    [Test]
+    public void MixedParams_PreservesAllAttributes()
+    {
+        var parameters = GetWrappedProcessMethod(new MixedTarget()).GetParameters();
+        // param 0: [In]
+        Assert.That(parameters[0].IsIn, Is.True);
+        Assert.That(parameters[0].IsOut, Is.False);
+        // param 1: [Out]
+        Assert.That(parameters[1].IsOut, Is.True);
+        Assert.That(parameters[1].IsIn, Is.False);
+        // param 2: no attributes
+        Assert.That(parameters[2].IsIn, Is.False);
+        Assert.That(parameters[2].IsOut, Is.False);
+    }
+
+    #endregion
+
+    #region Wrapper type structure
+
+    [Test]
+    public void WrappedType_HasRuntimeField()
+    {
+        dynamic wrapped = _runner.Wrap(new NoAttributeTarget());
+        Type wt = ((object)wrapped).GetType();
+        var field = wt.GetField("runtime", BindingFlags.Public | BindingFlags.Instance);
+        Assert.That(field, Is.Not.Null);
+        Assert.That(field.FieldType, Is.EqualTo(typeof(HybRunner)));
+    }
+
+    [Test]
+    public void WrappedType_HasWrappedField()
+    {
+        dynamic wrapped = _runner.Wrap(new NoAttributeTarget());
+        Type wt = ((object)wrapped).GetType();
+        var field = wt.GetField("wrapped", BindingFlags.Public | BindingFlags.Instance);
+        Assert.That(field, Is.Not.Null);
+        Assert.That(field.FieldType, Is.EqualTo(typeof(object)));
+    }
+
+    [Test]
+    public void WrappedMethod_ReturnsInt()
+    {
+        var method = GetWrappedProcessMethod(new NoAttributeTarget());
+        Assert.That(method.ReturnType, Is.EqualTo(typeof(int)));
+    }
+
+    #endregion
+
+    #region IL size differential
+
+    [Test]
+    public void InOnly_LargerILThan_NoAttributes()
+    {
+        var ilNoAttr = GetWrappedProcessIL(new NoAttributeTarget());
+        var ilIn = GetWrappedProcessIL(new InOnlyTarget());
+        Assert.That(ilIn.Length, Is.GreaterThan(ilNoAttr.Length),
+            "[In]-only IL should be larger due to extra ldc.i4.1 + different call target");
+    }
+
+    [Test]
+    public void OutOnly_LargerILThan_NoAttributes()
+    {
+        var ilNoAttr = GetWrappedProcessIL(new NoAttributeTarget());
+        var ilOut = GetWrappedProcessIL(new OutOnlyTarget());
+        Assert.That(ilOut.Length, Is.GreaterThan(ilNoAttr.Length),
+            "[Out]-only IL should be larger due to extra ldc.i4.1 + different call target");
+    }
+
+    #endregion
+
+    #region Call target resolution (best-effort)
+
+    [Test]
+    public void OutOnly_CallsMarshalManagedToNativeWithSkip()
+    {
+        var method = GetWrappedProcessMethod(new OutOnlyTarget());
+        var targets = TryResolveCallTargets(method);
+        if (targets == null)
+        {
+            Assert.Ignore("Module.ResolveMethod not supported on this dynamic module");
+            return;
+        }
+
+        // The skip variant is MarshalManagedToNative(object, bool) - 2 parameters
+        var marshalCalls = targets.Where(t => t.Name == "MarshalManagedToNative").ToList();
+        Assert.That(marshalCalls.Any(m => m.GetParameters().Length == 2), Is.True,
+            "[Out] should call the 2-parameter MarshalManagedToNative (with skipMemcpy)");
+    }
+
+    [Test]
+    public void InOnly_CallsCleanUpManagedDataWithSkip()
+    {
+        var method = GetWrappedProcessMethod(new InOnlyTarget());
+        var targets = TryResolveCallTargets(method);
+        if (targets == null)
+        {
+            Assert.Ignore("Module.ResolveMethod not supported on this dynamic module");
+            return;
+        }
+
+        var cleanupCalls = targets.Where(t => t.Name == "CleanUpManagedData").ToList();
+        Assert.That(cleanupCalls.Any(m => m.GetParameters().Length == 2), Is.True,
+            "[In] should call the 2-parameter CleanUpManagedData (with skipMemcpy)");
+    }
+
+    [Test]
+    public void NoAttributes_DoesNotCallSkipVariants()
+    {
+        var method = GetWrappedProcessMethod(new NoAttributeTarget());
+        var targets = TryResolveCallTargets(method);
+        if (targets == null)
+        {
+            Assert.Ignore("Module.ResolveMethod not supported on this dynamic module");
+            return;
+        }
+
+        var marshalCalls = targets.Where(t => t.Name == "MarshalManagedToNative").ToList();
+        var cleanupCalls = targets.Where(t => t.Name == "CleanUpManagedData").ToList();
+        // No 2-parameter overloads for the parameter (self is always non-skip)
+        // For the parameter call, only 1-parameter overloads should be used
+        Assert.That(marshalCalls.All(m => m.GetParameters().Length == 1), Is.True,
+            "No attributes: all MarshalManagedToNative calls should be 1-parameter");
+        Assert.That(cleanupCalls.All(m => m.GetParameters().Length == 1), Is.True,
+            "No attributes: all CleanUpManagedData calls should be 1-parameter");
+    }
+
+    #endregion
+}
+
+#region Test target classes
+
+public class NoAttributeTarget
+{
+    [EntryPoint]
+    public void Process(double[] data) { }
+}
+
+public class InOnlyTarget
+{
+    [EntryPoint]
+    public void Process([In] double[] data) { }
+}
+
+public class OutOnlyTarget
+{
+    [EntryPoint]
+    public void Process([Out] double[] data) { }
+}
+
+public class InOutTarget
+{
+    [EntryPoint]
+    public void Process([In, Out] double[] data) { }
+}
+
+public class MixedTarget
+{
+    [EntryPoint]
+    public void Process([In] double[] input, [Out] double[] output, double[] both) { }
+}
+
+public class StaticInOnlyTarget
+{
+    [EntryPoint]
+    public static void Process([In] double[] data) { }
+}
+
+#endregion

--- a/tests/SkipMemcpyTests.cs
+++ b/tests/SkipMemcpyTests.cs
@@ -1,0 +1,673 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using Hybridizer.Runtime.CUDAImports;
+using System.Runtime.CompilerServices;
+
+namespace Hybridizer.Runtime.CUDAImports.Tests;
+
+/// <summary>
+/// Tests for the skipMemcpy parameter flowing through the marshalling call graph.
+/// These tests use MainMemoryMarshaler (no GPU required).
+/// </summary>
+public class SkipMemcpyTests
+{
+    private MainMemoryMarshaler marshaller;
+
+    [SetUp]
+    public void SetUp()
+    {
+        marshaller = MainMemoryMarshaler.Create(HybridizerFlavor.OMP);
+    }
+
+    #region MarshalManagedToNative with skipMemcpy
+
+    [Test]
+    public void MarshalClass_SkipMemcpy_ReturnsNonZeroPointer()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, true);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+    }
+
+    [Test]
+    public void MarshalClass_NoSkip_ReturnsNonZeroPointer()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, false);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+    }
+
+    [Test]
+    public void MarshalArray_SkipMemcpy_ReturnsNonZeroPointer()
+    {
+        double[] array = { 1.0, 2.0, 3.0 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(array, true);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+    }
+
+    [Test]
+    public void MarshalArray_NoSkip_ReturnsNonZeroPointer()
+    {
+        double[] array = { 1.0, 2.0, 3.0 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(array, false);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+    }
+
+    [Test]
+    public void MarshalNull_SkipMemcpy_ReturnsZero()
+    {
+        IntPtr ptr = marshaller.MarshalManagedToNative(null, true);
+        Assert.That(ptr, Is.EqualTo(IntPtr.Zero));
+    }
+
+    [Test]
+    public void MarshalPrimitive_SkipMemcpy_IgnoresSkipFlag()
+    {
+        // Primitives are passed by value, skipMemcpy should have no effect
+        IntPtr ptr1 = marshaller.MarshalManagedToNative(42, false);
+        IntPtr ptr2 = marshaller.MarshalManagedToNative(42, true);
+        Assert.That(ptr1, Is.EqualTo(ptr2));
+    }
+
+    [Test]
+    public void MarshalStruct_SkipMemcpy_ReturnsNonZeroPointer()
+    {
+        var instance = new MyTestStruct { X = 1.0, Y = 2.0 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, true);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+    }
+
+    #endregion
+
+    #region Default parameter (backward compatibility)
+
+    [Test]
+    public void MarshalClass_DefaultOverload_StillWorks()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        // The original single-arg overload should still work
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+    }
+
+    [Test]
+    public unsafe void MarshalClass_DefaultOverload_DataIsCorrect()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance);
+
+        // Layout: VTABLE(8) + Value(double, 8) + Count(int, 4) + padding(4)
+        double* doubles = (double*)ptr;
+        Assert.That(doubles[0], Is.EqualTo(0));    // vtable
+        Assert.That(doubles[1], Is.EqualTo(42.0)); // Value
+        Assert.That(((int*)ptr)[4], Is.EqualTo(7)); // Count at byte offset 16
+    }
+
+    #endregion
+
+    #region CleanUpManagedData with skipMemcpy
+
+    [Test]
+    public void CleanUpManagedData_SkipMemcpy_CleansUpWithoutError()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance);
+        Assert.That(marshaller.NbelementsInGhost, Is.GreaterThan(0));
+
+        // CleanUp with skipMemcpy = true (FreeObjectGraph path)
+        marshaller.CleanUpManagedData(instance, true);
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    [Test]
+    public void CleanUpManagedData_NoSkip_CleansUpWithoutError()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance);
+        Assert.That(marshaller.NbelementsInGhost, Is.GreaterThan(0));
+
+        // CleanUp with skipMemcpy = false (deserializer path)
+        marshaller.CleanUpManagedData(instance, false);
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    [Test]
+    public void CleanUpManagedData_DefaultOverload_CleansUp()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        marshaller.MarshalManagedToNative(instance);
+        marshaller.CleanUpManagedData(instance);
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    [Test]
+    public void CleanUpManagedData_Array_SkipMemcpy_CleansUp()
+    {
+        double[] array = { 1.0, 2.0, 3.0 };
+        marshaller.MarshalManagedToNative(array);
+        Assert.That(marshaller.NbelementsInGhost, Is.GreaterThan(0));
+
+        marshaller.CleanUpManagedData(array, true);
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    #endregion
+
+    #region CleanUpNativeData with skipMemcpy
+
+    [Test]
+    public void CleanUpNativeData_SkipMemcpy_CleansUp()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance);
+        Assert.That(marshaller.NbelementsInGhost, Is.GreaterThan(0));
+
+        marshaller.CleanUpNativeData(ptr, true);
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    [Test]
+    public void CleanUpNativeData_NoSkip_CleansUp()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance);
+
+        marshaller.CleanUpNativeData(ptr, false);
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    [Test]
+    public void CleanUpNativeData_DefaultOverload_CleansUp()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance);
+
+        marshaller.CleanUpNativeData(ptr);
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    #endregion
+
+    #region FreeObjectGraph — nested objects
+
+    [Test]
+    public void CleanUpManagedData_SkipMemcpy_ClassWithNestedArray()
+    {
+        var instance = new MyClassWithNestedArray
+        {
+            Data = new double[] { 1.0, 2.0, 3.0 },
+            Factor = 2.0
+        };
+        marshaller.MarshalManagedToNative(instance);
+        int ghostsBefore = marshaller.NbelementsInGhost;
+        Assert.That(ghostsBefore, Is.GreaterThan(1)); // instance + Data array
+
+        marshaller.CleanUpManagedData(instance, true);
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    [Test]
+    public void CleanUpManagedData_SkipMemcpy_ClassWithNestedObject()
+    {
+        var inner = new MyTestClass { Value = 3.14, Count = 1 };
+        var outer = new MyClassWithNestedObject
+        {
+            Inner = inner,
+            Tag = 99
+        };
+        marshaller.MarshalManagedToNative(outer);
+        int ghostsBefore = marshaller.NbelementsInGhost;
+        Assert.That(ghostsBefore, Is.GreaterThan(1)); // outer + inner
+
+        marshaller.CleanUpManagedData(outer, true);
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    [Test]
+    public void CleanUpManagedData_SkipMemcpy_ObjectArrayOfClasses()
+    {
+        var arr = new MyTestClass[]
+        {
+            new MyTestClass { Value = 1.0, Count = 1 },
+            new MyTestClass { Value = 2.0, Count = 2 },
+            null
+        };
+        marshaller.MarshalManagedToNative(arr);
+        Assert.That(marshaller.NbelementsInGhost, Is.GreaterThan(1));
+
+        marshaller.CleanUpManagedData(arr, true);
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    #endregion
+
+    #region Marshal then skipMemcpy cleanup preserves managed data
+
+    [Test]
+    public unsafe void MarshalAndSkipCleanup_ManagedDataUnchanged()
+    {
+        // When we skipMemcpy on cleanup, managed data should NOT be updated from native
+        // With MainMemory marshaler the data is pinned so it's the same memory,
+        // but the cleanup path (FreeObjectGraph) should not touch managed fields
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance);
+
+        // Modify native memory directly
+        double* doubles = (double*)ptr;
+        doubles[2] = 999.0; // modify the Value field in native memory
+
+        // Cleanup with skipMemcpy = true — should NOT deserialize back
+        marshaller.CleanUpManagedData(instance, true);
+
+        // For MainMemory, since it's pinned, the value might already be reflected.
+        // The key thing is that the cleanup doesn't crash and the state is clean.
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    #endregion
+
+    #region Round-trip with normal (non-skip) cleanup
+
+    [Test]
+    public unsafe void MarshalAndCleanup_NoSkip_RoundTrip()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, false);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+
+        marshaller.CleanUpManagedData(instance, false);
+        Assert.That(instance.Value, Is.EqualTo(42.0));
+        Assert.That(instance.Count, Is.EqualTo(7));
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    #endregion
+
+    #region Simulate [Out]-only: skipMemcpy on marshal, normal cleanup
+
+    [Test]
+    public void SimulateOutOnly_SkipMarshal_NormalCleanup()
+    {
+        // [Out] parameter: skip memcpy H→D (marshal with skip), normal D→H cleanup
+        var instance = new MyTestClass { Value = 0.0, Count = 0 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, true); // skip H→D
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+
+        marshaller.CleanUpManagedData(instance, false); // normal D→H
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    #endregion
+
+    #region Simulate [In]-only: normal marshal, skipMemcpy on cleanup
+
+    [Test]
+    public void SimulateInOnly_NormalMarshal_SkipCleanup()
+    {
+        // [In] parameter: normal H→D marshal, skip memcpy D→H (cleanup with skip)
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, false); // normal H→D
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+
+        marshaller.CleanUpManagedData(instance, true); // skip D→H
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    #endregion
+
+    #region Multiple parameters scenario
+
+    [Test]
+    public void MultipleObjects_MixedSkipBehavior()
+    {
+        // Simulate a call with multiple params having different In/Out attributes
+        var inParam = new MyTestClass { Value = 1.0, Count = 1 };       // [In]
+        var outParam = new MyTestClass { Value = 0.0, Count = 0 };      // [Out]
+        var inoutParam = new MyTestClass { Value = 3.0, Count = 3 };    // [In,Out]
+
+        // Marshal: [In] normal, [Out] skip, [In,Out] normal
+        IntPtr ptrIn = marshaller.MarshalManagedToNative(inParam, false);
+        IntPtr ptrOut = marshaller.MarshalManagedToNative(outParam, true);
+        IntPtr ptrInOut = marshaller.MarshalManagedToNative(inoutParam, false);
+
+        Assert.That(ptrIn, Is.Not.EqualTo(IntPtr.Zero));
+        Assert.That(ptrOut, Is.Not.EqualTo(IntPtr.Zero));
+        Assert.That(ptrInOut, Is.Not.EqualTo(IntPtr.Zero));
+
+        // Cleanup: [In] skip, [Out] normal, [In,Out] normal
+        marshaller.CleanUpManagedData(inParam, true);
+        marshaller.CleanUpManagedData(outParam, false);
+        marshaller.CleanUpManagedData(inoutParam, false);
+
+        Assert.That(marshaller.IsClean(), Is.True);
+    }
+
+    #endregion
+
+    #region Ghost count tracking
+
+    [Test]
+    public void GhostCount_IncreasesOnMarshal_DecreasesOnCleanup()
+    {
+        Assert.That(marshaller.NbelementsInGhost, Is.EqualTo(0));
+
+        var instance = new MyTestClass { Value = 1.0, Count = 1 };
+        marshaller.MarshalManagedToNative(instance);
+        Assert.That(marshaller.NbelementsInGhost, Is.GreaterThan(0));
+
+        marshaller.CleanUpManagedData(instance, true);
+        Assert.That(marshaller.NbelementsInGhost, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GhostCount_SkipMarshal_StillTracked()
+    {
+        var instance = new MyTestClass { Value = 1.0, Count = 1 };
+        marshaller.MarshalManagedToNative(instance, true);
+        Assert.That(marshaller.NbelementsInGhost, Is.GreaterThan(0));
+
+        marshaller.CleanUpManagedData(instance, true);
+        Assert.That(marshaller.NbelementsInGhost, Is.EqualTo(0));
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Tests for [In]/[Out] attribute detection via reflection.
+/// Verifies that ParameterInfo.IsIn/IsOut correctly reflects attributes.
+/// </summary>
+public class InOutAttributeReflectionTests
+{
+    private static void MethodWithInParam([In] double[] data) { }
+    private static void MethodWithOutParam([Out] double[] data) { }
+    private static void MethodWithInOutParam([In, Out] double[] data) { }
+    private static void MethodWithNoAttributes(double[] data) { }
+
+    [Test]
+    public void InAttribute_IsDetected()
+    {
+        var mi = typeof(InOutAttributeReflectionTests).GetMethod(nameof(MethodWithInParam),
+            BindingFlags.Static | BindingFlags.NonPublic);
+        var pi = mi.GetParameters()[0];
+        Assert.That(pi.IsIn, Is.True);
+        Assert.That(pi.IsOut, Is.False);
+    }
+
+    [Test]
+    public void OutAttribute_IsDetected()
+    {
+        var mi = typeof(InOutAttributeReflectionTests).GetMethod(nameof(MethodWithOutParam),
+            BindingFlags.Static | BindingFlags.NonPublic);
+        var pi = mi.GetParameters()[0];
+        Assert.That(pi.IsOut, Is.True);
+        Assert.That(pi.IsIn, Is.False);
+    }
+
+    [Test]
+    public void InOutAttributes_BothDetected()
+    {
+        var mi = typeof(InOutAttributeReflectionTests).GetMethod(nameof(MethodWithInOutParam),
+            BindingFlags.Static | BindingFlags.NonPublic);
+        var pi = mi.GetParameters()[0];
+        Assert.That(pi.IsIn, Is.True);
+        Assert.That(pi.IsOut, Is.True);
+    }
+
+    [Test]
+    public void NoAttributes_NeitherDetected()
+    {
+        var mi = typeof(InOutAttributeReflectionTests).GetMethod(nameof(MethodWithNoAttributes),
+            BindingFlags.Static | BindingFlags.NonPublic);
+        var pi = mi.GetParameters()[0];
+        Assert.That(pi.IsIn, Is.False);
+        Assert.That(pi.IsOut, Is.False);
+    }
+
+    [Test]
+    public void InOnly_SkipLogic_IsCorrect()
+    {
+        var mi = typeof(InOutAttributeReflectionTests).GetMethod(nameof(MethodWithInParam),
+            BindingFlags.Static | BindingFlags.NonPublic);
+        var pi = mi.GetParameters()[0];
+
+        // [In] only → skip D→H on cleanup
+        bool isInOnly = pi.IsIn && !pi.IsOut;
+        Assert.That(isInOnly, Is.True);
+    }
+
+    [Test]
+    public void OutOnly_SkipLogic_IsCorrect()
+    {
+        var mi = typeof(InOutAttributeReflectionTests).GetMethod(nameof(MethodWithOutParam),
+            BindingFlags.Static | BindingFlags.NonPublic);
+        var pi = mi.GetParameters()[0];
+
+        // [Out] only → skip H→D on marshal
+        bool isOutOnly = pi.IsOut && !pi.IsIn;
+        Assert.That(isOutOnly, Is.True);
+    }
+
+    [Test]
+    public void InOut_NoSkipOnEitherSide()
+    {
+        var mi = typeof(InOutAttributeReflectionTests).GetMethod(nameof(MethodWithInOutParam),
+            BindingFlags.Static | BindingFlags.NonPublic);
+        var pi = mi.GetParameters()[0];
+
+        bool isInOnly = pi.IsIn && !pi.IsOut;
+        bool isOutOnly = pi.IsOut && !pi.IsIn;
+        Assert.That(isInOnly, Is.False);
+        Assert.That(isOutOnly, Is.False);
+    }
+
+    [Test]
+    public void NoAttributes_NoSkipOnEitherSide()
+    {
+        var mi = typeof(InOutAttributeReflectionTests).GetMethod(nameof(MethodWithNoAttributes),
+            BindingFlags.Static | BindingFlags.NonPublic);
+        var pi = mi.GetParameters()[0];
+
+        bool isInOnly = pi.IsIn && !pi.IsOut;
+        bool isOutOnly = pi.IsOut && !pi.IsIn;
+        Assert.That(isInOnly, Is.False);
+        Assert.That(isOutOnly, Is.False);
+    }
+}
+
+/// <summary>
+/// CUDA-specific tests that require a GPU and CUDA driver.
+/// Run with: dotnet test --filter "TestCategory=CUDA"
+/// </summary>
+[TestFixture, Category("CUDA")]
+public class CudaSkipMemcpyTests
+{
+    private CudaMarshaler marshaller;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        if (!cuda.IsCudaAvailable())
+            Assert.Ignore("CUDA is not available — skipping GPU tests");
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        marshaller = CudaMarshaler.Create(false);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        marshaller?.Free();
+    }
+
+    [Test]
+    public void CudaMarshalClass_NoSkip_ReturnsDevicePointer()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, false);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+        marshaller.CleanUpManagedData(instance, false);
+        Assert.That(cuda.DeviceSynchronize(), Is.EqualTo(cudaError_t.cudaSuccess));
+    }
+
+    [Test]
+    public void CudaMarshalClass_SkipMemcpy_ReturnsDevicePointer()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, true);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+        marshaller.CleanUpManagedData(instance, true);
+        Assert.That(cuda.DeviceSynchronize(), Is.EqualTo(cudaError_t.cudaSuccess));
+    }
+
+    [Test]
+    public void CudaMarshalArray_NoSkip_ReturnsDevicePointer()
+    {
+        double[] array = { 1.0, 2.0, 3.0, 4.0, 5.0 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(array, false);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+        marshaller.CleanUpManagedData(array, false);
+        Assert.That(cuda.DeviceSynchronize(), Is.EqualTo(cudaError_t.cudaSuccess));
+    }
+
+    [Test]
+    public void CudaMarshalArray_SkipMemcpy_ReturnsDevicePointer()
+    {
+        // [Out] scenario: allocate on GPU, no H→D copy
+        double[] array = { 1.0, 2.0, 3.0, 4.0, 5.0 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(array, true);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+        marshaller.CleanUpManagedData(array, true);
+        Assert.That(cuda.DeviceSynchronize(), Is.EqualTo(cudaError_t.cudaSuccess));
+    }
+
+    [Test]
+    public void CudaCleanUp_SkipMemcpy_FreesWithoutError()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        marshaller.MarshalManagedToNative(instance, false);
+        Assert.That(marshaller.NbelementsInGhost, Is.GreaterThan(0));
+
+        // [In] scenario: skip D→H on cleanup
+        marshaller.CleanUpManagedData(instance, true);
+        Assert.That(marshaller.IsClean(), Is.True);
+        Assert.That(cuda.DeviceSynchronize(), Is.EqualTo(cudaError_t.cudaSuccess));
+    }
+
+    [Test]
+    public void CudaCleanUp_NoSkip_DeserializesBack()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, false);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+
+        marshaller.CleanUpManagedData(instance, false);
+        Assert.That(instance.Value, Is.EqualTo(42.0));
+        Assert.That(instance.Count, Is.EqualTo(7));
+        Assert.That(marshaller.IsClean(), Is.True);
+        Assert.That(cuda.DeviceSynchronize(), Is.EqualTo(cudaError_t.cudaSuccess));
+    }
+
+    [Test]
+    public void CudaSimulateOutOnly_SkipMarshal_NormalCleanup()
+    {
+        double[] output = new double[100];
+        IntPtr ptr = marshaller.MarshalManagedToNative(output, true); // skip H→D
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+
+        marshaller.CleanUpManagedData(output, false); // normal D→H
+        Assert.That(marshaller.IsClean(), Is.True);
+        Assert.That(cuda.DeviceSynchronize(), Is.EqualTo(cudaError_t.cudaSuccess));
+    }
+
+    [Test]
+    public void CudaSimulateInOnly_NormalMarshal_SkipCleanup()
+    {
+        double[] input = [1.0, 2.0, 3.0];
+        IntPtr ptr = marshaller.MarshalManagedToNative(input, false); // normal H→D
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+
+        marshaller.CleanUpManagedData(input, true); // skip D→H
+        Assert.That(marshaller.IsClean(), Is.True);
+        Assert.That(cuda.DeviceSynchronize(), Is.EqualTo(cudaError_t.cudaSuccess));
+    }
+
+    [Test]
+    public void CudaNestedObject_SkipCleanup_FreesAll()
+    {
+        var instance = new MyClassWithNestedArray
+        {
+            Data = [1.0, 2.0, 3.0],
+            Factor = 2.0
+        };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, false);
+        Assert.That(marshaller.NbelementsInGhost, Is.GreaterThan(1));
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+
+        marshaller.CleanUpManagedData(instance, true);
+        Assert.That(marshaller.IsClean(), Is.True);
+        Assert.That(cuda.DeviceSynchronize(), Is.EqualTo(cudaError_t.cudaSuccess));
+    }
+
+    [Test]
+    public void CudaCleanUpNativeData_SkipMemcpy()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, false);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+
+        marshaller.CleanUpNativeData(ptr, true);
+        Assert.That(marshaller.IsClean(), Is.True);
+        Assert.That(cuda.DeviceSynchronize(), Is.EqualTo(cudaError_t.cudaSuccess));
+    }
+
+    [Test]
+    public void CudaCleanUpNativeData_NoSkip()
+    {
+        var instance = new MyTestClass { Value = 42.0, Count = 7 };
+        IntPtr ptr = marshaller.MarshalManagedToNative(instance, false);
+        Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero));
+        marshaller.CleanUpNativeData(ptr, false);
+        Assert.That(marshaller.IsClean(), Is.True);
+        Assert.That(cuda.DeviceSynchronize(), Is.EqualTo(cudaError_t.cudaSuccess));
+    }
+}
+
+#region Test helper types
+
+public class MyTestClass
+{
+    public int Count;
+    public double Value;
+}
+
+public struct MyTestStruct
+{
+    public double X;
+    public double Y;
+}
+
+public class MyClassWithArray
+{
+    public double[] Data;
+    public string Name;
+}
+
+public class MyClassWithNestedArray
+{
+    public double[] Data;
+    public double Factor;
+}
+
+public class MyClassWithNestedObject
+{
+    public MyTestClass Inner;
+    public int Tag;
+}
+
+#endregion


### PR DESCRIPTION
In CUDA, In and Out attributes trigger memcpy the right way
+ fix on griddim on one setDistrib call which led to kernel invoke corruption